### PR TITLE
Used shade plugin to create a runnable JAR file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+### Maven shade plugin ###
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,27 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>${javafx.maven.plugin.version}</version>
                 <configuration>
-                    <mainClass>carleton.sysc4907.Main</mainClass>
+                    <mainClass>carleton.sysc4907.App</mainClass>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>carleton.sysc4907.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/carleton/sysc4907/App.java
+++ b/src/main/java/carleton/sysc4907/App.java
@@ -1,0 +1,32 @@
+package carleton.sysc4907;
+
+import carleton.sysc4907.controller.SessionInfoBarController;
+import carleton.sysc4907.model.SessionModel;
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+
+public class App extends Application {
+
+    @Override
+    public void start(Stage stage) throws IOException {
+        //Create dependency injector to link models and controllers
+        DependencyInjector injector = new DependencyInjector();
+        //Create the session
+        SessionModel sessionModel = new SessionModel();
+        //Add instantiation methods to the dependency injector
+        injector.addInjectionMethod(SessionInfoBarController.class, () -> new SessionInfoBarController(sessionModel));
+
+        //Set up and show the scene
+        Scene scene = new Scene(injector.load("view/SessionInfoBar.fxml"), 640, 480);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch();
+    }
+
+}

--- a/src/main/java/carleton/sysc4907/Main.java
+++ b/src/main/java/carleton/sysc4907/Main.java
@@ -1,32 +1,13 @@
 package carleton.sysc4907;
 
-import carleton.sysc4907.controller.SessionInfoBarController;
-import carleton.sysc4907.model.SessionModel;
-import javafx.application.Application;
-import javafx.scene.Scene;
-import javafx.stage.Stage;
+public class Main {
 
-import java.io.IOException;
-
-public class Main extends Application {
-
-    @Override
-    public void start(Stage stage) throws IOException {
-        //Create dependency injector to link models and controllers
-        DependencyInjector injector = new DependencyInjector();
-        //Create the session
-        SessionModel sessionModel = new SessionModel();
-        //Add instantiation methods to the dependency injector
-        injector.addInjectionMethod(SessionInfoBarController.class, () -> new SessionInfoBarController(sessionModel));
-
-        //Set up and show the scene
-        Scene scene = new Scene(injector.load("view/SessionInfoBar.fxml"), 640, 480);
-        stage.setScene(scene);
-        stage.show();
-    }
-
+    /**
+     * Runs the application using the given command-line arguments.
+     * Used to create a runnable JAR file.
+     * @param args the command-line arguments
+     */
     public static void main(String[] args) {
-        launch();
+        App.main(args);
     }
-
 }


### PR DESCRIPTION
Renamed Main to App, created a new Main file that calls App. This new Main file is required to create the runnable JAR (this uses a plugin that can package the dependencies including javafx into the JAR itself); the new Main file can also be run via IntellliJ and will run correctly.

Example JAR (**remove the .zip that I added to the name**, GitHub does not like attaching JAR files for security reasons probably):
[uml-diagram-collab-1.0-SNAPSHOT.jar.zip](https://github.com/Andrei486/uml-diagram-collab/files/13184231/uml-diagram-collab-1.0-SNAPSHOT.jar.zip)

If someone could make sure that they can run the JAR, and possibly that the new Main file executes correctly on their end, that would be great.