### PR TITLE
Implement resize preview and command

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907;
 
+import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.controller.FormattingPanelController;
 import carleton.sysc4907.controller.SessionInfoBarController;
 import carleton.sysc4907.controller.SessionUsersMenuController;
@@ -37,11 +38,12 @@ public class DiagramEditorLoader {
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
         DependencyInjector elementControllerInjector = new DependencyInjector();
         MoveCommandFactory moveCommandFactory = new MoveCommandFactory();
+        ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory();
         // Add instantiation methods for the element injector, used to create diagram element controllers
         elementControllerInjector.addInjectionMethod(RectangleController.class,
-                () -> new RectangleController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator));
+                () -> new RectangleController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory));
         elementControllerInjector.addInjectionMethod(UmlCommentController.class,
-                () -> new UmlCommentController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator));
+                () -> new UmlCommentController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory));
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 EditableLabelController::new);
         // Add instantiation methods to the main dependency injector, used to create UI elements

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -67,7 +67,7 @@ public class DiagramEditorLoader {
         injector.addInjectionMethod(DiagramEditingAreaController.class,
                 () -> new DiagramEditingAreaController(diagramModel));
         injector.addInjectionMethod(ElementLibraryPanelController.class,
-                () -> new ElementLibraryPanelController(diagramModel, elementControllerInjector, addCommandFactory));
+                () -> new ElementLibraryPanelController(diagramModel, addCommandFactory));
 
         //Set up and show the scene
         Scene scene = new Scene(injector.load("view/DiagramEditorScreen.fxml"), 1280, 720);

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -36,14 +36,17 @@ public class DiagramEditorLoader {
         DiagramModel diagramModel = new DiagramModel();
         MovePreviewCreator movePreviewCreator = new MovePreviewCreator();
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
+        ResizePreviewCreator resizePreviewCreator = new ResizePreviewCreator();
         DependencyInjector elementControllerInjector = new DependencyInjector();
         MoveCommandFactory moveCommandFactory = new MoveCommandFactory();
         ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory();
         // Add instantiation methods for the element injector, used to create diagram element controllers
         elementControllerInjector.addInjectionMethod(RectangleController.class,
-                () -> new RectangleController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory));
+                () -> new RectangleController(movePreviewCreator, moveCommandFactory, diagramModel,
+                        resizeHandleCreator, resizePreviewCreator, resizeCommandFactory));
         elementControllerInjector.addInjectionMethod(UmlCommentController.class,
-                () -> new UmlCommentController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory));
+                () -> new UmlCommentController(movePreviewCreator, moveCommandFactory, diagramModel,
+                        resizeHandleCreator, resizePreviewCreator, resizeCommandFactory));
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 EditableLabelController::new);
         // Add instantiation methods to the main dependency injector, used to create UI elements

--- a/src/main/java/carleton/sysc4907/command/ResizeCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommand.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.ResizeCommandArgs;
 import carleton.sysc4907.view.DiagramElement;
+import javafx.scene.layout.Pane;
 
 public class ResizeCommand implements Command<ResizeCommandArgs> {
 
@@ -13,7 +14,7 @@ public class ResizeCommand implements Command<ResizeCommandArgs> {
 
     @Override
     public void execute() {
-        var element = (DiagramElement) args.element();
+        var element = args.element();
         var dragStartX = args.dragStartX();
         var dragStartY = args.dragStartY();
         var dragEndX = args.dragEndX();

--- a/src/main/java/carleton/sysc4907/command/ResizeCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommand.java
@@ -1,0 +1,39 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ResizeCommandArgs;
+import carleton.sysc4907.view.DiagramElement;
+
+public class ResizeCommand implements Command<ResizeCommandArgs> {
+
+    private final ResizeCommandArgs args;
+
+    public ResizeCommand(ResizeCommandArgs args) {
+        this.args = args;
+    }
+
+    @Override
+    public void execute() {
+        var element = (DiagramElement) args.element();
+        var dragStartX = args.dragStartX();
+        var dragStartY = args.dragStartY();
+        var dragEndX = args.dragEndX();
+        var dragEndY = args.dragEndY();
+        var isTopAnchor = args.isTopAnchor();
+        var isRightAnchor = args.isRightAnchor();
+
+        double widthChange = dragEndX - dragStartX;
+        widthChange = isRightAnchor ? widthChange : -widthChange;
+        widthChange = Math.max(widthChange, -element.getMaxWidth() + 20);
+        double heightChange = dragEndY - dragStartY;
+        heightChange = isTopAnchor ? -heightChange : heightChange;
+        heightChange = Math.max(heightChange, -element.getMaxHeight() + 20);
+        element.setMaxWidth(element.getMaxWidth() + widthChange);
+        element.setMaxHeight(element.getMaxHeight() + heightChange);
+        if (isTopAnchor) {
+            element.setLayoutY(element.getLayoutY() - heightChange);
+        }
+        if (!isRightAnchor) {
+            element.setLayoutX(element.getLayoutX() - widthChange);
+        }
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/ResizeCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommandFactory.java
@@ -1,0 +1,11 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ResizeCommandArgs;
+
+public class ResizeCommandFactory implements CommandFactory<Command<ResizeCommandArgs>, ResizeCommandArgs> {
+
+    @Override
+    public Command create(ResizeCommandArgs args) {
+        return new ResizeCommand(args);
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
@@ -1,6 +1,6 @@
 package carleton.sysc4907.command.args;
 
-import javafx.scene.Node;
+import javafx.scene.layout.Pane;
 
 public record ResizeCommandArgs(boolean isTopAnchor,
                                 boolean isRightAnchor,
@@ -8,6 +8,6 @@ public record ResizeCommandArgs(boolean isTopAnchor,
                                 double dragStartY,
                                 double dragEndX,
                                 double dragEndY,
-                                Node element) {
+                                Pane element) {
 
 }

--- a/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
@@ -1,0 +1,13 @@
+package carleton.sysc4907.command.args;
+
+import javafx.scene.Node;
+
+public record ResizeCommandArgs(boolean isTopAnchor,
+                                boolean isRightAnchor,
+                                double dragStartX,
+                                double dragStartY,
+                                double dragEndX,
+                                double dragEndY,
+                                Node element) {
+
+}

--- a/src/main/java/carleton/sysc4907/controller/DiagramEditorScreenController.java
+++ b/src/main/java/carleton/sysc4907/controller/DiagramEditorScreenController.java
@@ -26,12 +26,4 @@ public class DiagramEditorScreenController {
     @FXML
     private DiagramEditingAreaController diagramEditingAreaController;
 
-    /**
-     * Initializes the view, updating references to the editing area.
-     */
-    @FXML
-    public void initialize() {
-        elementLibraryPanelController.setEditingArea(diagramEditingAreaController.getEditingArea());
-        diagramMenuController.setEditingArea(diagramEditingAreaController.getEditingArea());
-    }
 }

--- a/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
+++ b/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
@@ -24,7 +24,6 @@ public class DiagramMenuBarController {
     @FXML
     private MenuBar menuBar;
 
-    private Pane editingArea;
     private final DiagramModel diagramModel;
 
     private final RemoveCommandFactory removeCommandFactory;
@@ -36,15 +35,6 @@ public class DiagramMenuBarController {
     public DiagramMenuBarController(DiagramModel diagramModel, RemoveCommandFactory removeCommandFactory) {
         this.diagramModel = diagramModel;
         this.removeCommandFactory = removeCommandFactory;
-    }
-
-    /**
-     * Sets the editing area where users can manipulate elements.
-     * Should be called on initialization.
-     * @param editingArea the new editing area
-     */
-    public void setEditingArea(Pane editingArea) {
-        this.editingArea = editingArea;
     }
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
+++ b/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
@@ -29,26 +29,14 @@ public class ElementLibraryPanelController {
     private TitledPane titledPane;
 
     private final DiagramModel diagramModel;
-    private final DependencyInjector elementInjector;
-    private Pane editingArea = null;
 
     /**
      * Constructs a new ElementLibraryPanelController.
      * @param diagramModel the DiagramModel for the current diagram
-     * @param elementInjector the DependencyInjector used to load new diagram elements from FXML
      */
-    public ElementLibraryPanelController(DiagramModel diagramModel, DependencyInjector elementInjector, AddCommandFactory addCommandFactory) {
+    public ElementLibraryPanelController(DiagramModel diagramModel, AddCommandFactory addCommandFactory) {
         this.diagramModel = diagramModel;
-        this.elementInjector = elementInjector;
         this.addCommandFactory = addCommandFactory;
-    }
-
-    /**
-     * Set the Pane to be used as the editing area when adding elements.
-     * @param editingArea the Pane to add elements to
-     */
-    public void setEditingArea(Pane editingArea) {
-        this.editingArea = editingArea;
     }
 
     @FXML

--- a/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907.controller.element;
 
+import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
@@ -34,7 +35,9 @@ public class MovePreviewCreator {
         preview.setOpacity(0.5);
         preview.setLayoutX(element.getLayoutX());
         preview.setLayoutY(element.getLayoutY());
-        ((Pane) element.getParent()).getChildren().add(preview);
+
+        Pane editingArea = EditingAreaProvider.getEditingArea();
+        editingArea.getChildren().add(preview);
         return preview;
     }
 

--- a/src/main/java/carleton/sysc4907/controller/element/RectangleController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/RectangleController.java
@@ -1,6 +1,7 @@
 package carleton.sysc4907.controller.element;
 
 import carleton.sysc4907.command.MoveCommandFactory;
+import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.fxml.FXML;
 import javafx.scene.shape.Rectangle;
@@ -14,8 +15,9 @@ public class RectangleController extends ResizableElementController {
             MovePreviewCreator previewCreator,
             MoveCommandFactory moveCommandFactory,
             DiagramModel diagramModel,
-            ResizeHandleCreator resizeHandleCreator) {
-        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator);
+            ResizeHandleCreator resizeHandleCreator,
+            ResizeCommandFactory resizeCommandFactory) {
+        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory);
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/controller/element/RectangleController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/RectangleController.java
@@ -16,8 +16,9 @@ public class RectangleController extends ResizableElementController {
             MoveCommandFactory moveCommandFactory,
             DiagramModel diagramModel,
             ResizeHandleCreator resizeHandleCreator,
+            ResizePreviewCreator resizePreviewCreator,
             ResizeCommandFactory resizeCommandFactory) {
-        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory);
+        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizePreviewCreator, resizeCommandFactory);
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -1,6 +1,10 @@
 package carleton.sysc4907.controller.element;
 
+import carleton.sysc4907.command.Command;
 import carleton.sysc4907.command.MoveCommandFactory;
+import carleton.sysc4907.command.ResizeCommand;
+import carleton.sysc4907.command.ResizeCommandFactory;
+import carleton.sysc4907.command.args.ResizeCommandArgs;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.collections.ListChangeListener;
@@ -17,6 +21,7 @@ public abstract class ResizableElementController extends DiagramElementControlle
     private final List<Node> resizeHandles;
 
     private final ResizeHandleCreator resizeHandleCreator;
+    private final ResizeCommandFactory resizeCommandFactory;
 
     private double resizeDragStartX = 0;
     private double resizeDragStartY = 0;
@@ -34,9 +39,11 @@ public abstract class ResizableElementController extends DiagramElementControlle
             MovePreviewCreator previewCreator,
             MoveCommandFactory moveCommandFactory,
             DiagramModel diagramModel,
-            ResizeHandleCreator resizeHandleCreator) {
+            ResizeHandleCreator resizeHandleCreator,
+            ResizeCommandFactory resizeCommandFactory) {
         super(previewCreator, moveCommandFactory, diagramModel);
         this.resizeHandleCreator = resizeHandleCreator;
+        this.resizeCommandFactory = resizeCommandFactory;
         this.resizeHandles = new LinkedList<>();
         diagramModel.getSelectedElements().addListener((ListChangeListener<DiagramElement>) change -> {
             while (change.next()) {
@@ -74,12 +81,16 @@ public abstract class ResizableElementController extends DiagramElementControlle
                 if (!resizeDragging) {
                     return;
                 }
-                resize(isTop,
+                var command = resizeCommandFactory.create(new ResizeCommandArgs(
+                        isTop,
                         isRight,
                         resizeDragStartX,
                         resizeDragStartY,
                         event.getSceneX(),
-                        event.getSceneY());
+                        event.getSceneY(),
+                        element
+                ));
+                command.execute();
                 resizeDragging = false;
                 toggleShowResizeHandles(false);
                 toggleShowResizeHandles(true);

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -1,8 +1,6 @@
 package carleton.sysc4907.controller.element;
 
-import carleton.sysc4907.command.Command;
 import carleton.sysc4907.command.MoveCommandFactory;
-import carleton.sysc4907.command.ResizeCommand;
 import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.command.args.ResizeCommandArgs;
 import carleton.sysc4907.view.DiagramElement;
@@ -10,6 +8,9 @@ import carleton.sysc4907.model.DiagramModel;
 import javafx.collections.ListChangeListener;
 import javafx.event.Event;
 import javafx.scene.Node;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.Pane;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -22,9 +23,13 @@ public abstract class ResizableElementController extends DiagramElementControlle
 
     private final ResizeHandleCreator resizeHandleCreator;
     private final ResizeCommandFactory resizeCommandFactory;
+    private final ResizePreviewCreator resizePreviewCreator;
+    private Pane preview = null;
 
     private double resizeDragStartX = 0;
     private double resizeDragStartY = 0;
+    private double lastPreviewDragX = 0;
+    private double lastPreviewDragY = 0;
 
     private boolean resizeDragging = false;
 
@@ -40,9 +45,11 @@ public abstract class ResizableElementController extends DiagramElementControlle
             MoveCommandFactory moveCommandFactory,
             DiagramModel diagramModel,
             ResizeHandleCreator resizeHandleCreator,
+            ResizePreviewCreator resizePreviewCreator,
             ResizeCommandFactory resizeCommandFactory) {
         super(previewCreator, moveCommandFactory, diagramModel);
         this.resizeHandleCreator = resizeHandleCreator;
+        this.resizePreviewCreator = resizePreviewCreator;
         this.resizeCommandFactory = resizeCommandFactory;
         this.resizeHandles = new LinkedList<>();
         diagramModel.getSelectedElements().addListener((ListChangeListener<DiagramElement>) change -> {
@@ -70,32 +77,9 @@ public abstract class ResizableElementController extends DiagramElementControlle
             boolean isTop = i % 2 == 0;
             boolean isRight = i / 2 == 0;
             Node handle = resizeHandleCreator.createResizeHandle(element, isTop, isRight);
-            handle.setOnDragDetected(event -> {
-                resizeDragging = true;
-                resizeDragStartX = event.getSceneX();
-                resizeDragStartY = event.getSceneY();
-                event.consume();
-            });
-            handle.setOnMouseDragged(Event::consume);
-            handle.setOnMouseReleased(event -> {
-                if (!resizeDragging) {
-                    return;
-                }
-                var command = resizeCommandFactory.create(new ResizeCommandArgs(
-                        isTop,
-                        isRight,
-                        resizeDragStartX,
-                        resizeDragStartY,
-                        event.getSceneX(),
-                        event.getSceneY(),
-                        element
-                ));
-                command.execute();
-                resizeDragging = false;
-                toggleShowResizeHandles(false);
-                toggleShowResizeHandles(true);
-                event.consume();
-            });
+            handle.setOnDragDetected(this::handleDragDetectedStartResize);
+            handle.setOnMouseDragged(event -> handleMouseDraggedResizePreview(event, isTop, isRight));
+            handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, isTop, isRight));
             handle.setOnMouseClicked(Event::consume);
             resizeHandles.add(handle);
         }
@@ -112,26 +96,67 @@ public abstract class ResizableElementController extends DiagramElementControlle
         }
     }
 
-    public void resize(
-            boolean isTopAnchor,
-            boolean isRightAnchor,
-            double dragStartX,
-            double dragStartY,
-            double dragEndX,
-            double dragEndY) {
-        double widthChange = dragEndX - dragStartX;
-        widthChange = isRightAnchor ? widthChange : -widthChange;
-        widthChange = Math.max(widthChange, -element.getMaxWidth() + 20);
-        double heightChange = dragEndY - dragStartY;
-        heightChange = isTopAnchor ? -heightChange : heightChange;
-        heightChange = Math.max(heightChange, -element.getMaxHeight() + 20);
-        element.setMaxWidth(element.getMaxWidth() + widthChange);
-        element.setMaxHeight(element.getMaxHeight() + heightChange);
-        if (isTopAnchor) {
-            element.setLayoutY(element.getLayoutY() - heightChange);
+    private void handleDragDetectedStartResize(MouseEvent event) {
+        resizeDragging = true;
+        resizeDragStartX = event.getSceneX();
+        resizeDragStartY = event.getSceneY();
+        lastPreviewDragX = resizeDragStartX;
+        lastPreviewDragY = resizeDragStartY;
+        resizePreviewCreator.deleteResizePreview(element, preview);
+        element.getStyleClass().removeAll(SELECTED_STYLE_CLASS);
+        preview = resizePreviewCreator.createResizePreview(element);
+        element.getStyleClass().add(SELECTED_STYLE_CLASS);
+        event.consume();
+    }
+
+    private void handleMouseDraggedResizePreview(MouseEvent event, boolean isTop, boolean isRight) {
+        // Handle left click only
+        if (!event.isPrimaryButtonDown()) {
+            return;
         }
-        if (!isRightAnchor) {
-            element.setLayoutX(element.getLayoutX() - widthChange);
+        if (preview != null) {
+            // Reset the preview and resize it from there. This is to avoid issues where the preview becomes desynced
+            // because of the minimum size. Alternatively we could make an entirely separate command for this, since
+            // it isn't actually affecting the diagram.
+            preview.setMaxWidth(element.getMaxWidth());
+            preview.setMaxHeight(element.getMaxHeight());
+            preview.setLayoutX(element.getLayoutX());
+            preview.setLayoutY(element.getLayoutY());
+            ResizeCommandArgs args = new ResizeCommandArgs(
+                    isTop,
+                    isRight,
+                    resizeDragStartX,
+                    resizeDragStartY,
+                    event.getSceneX(),
+                    event.getSceneY(),
+                    preview
+            );
+            var command = resizeCommandFactory.create(args);
+            command.execute();
         }
+        lastPreviewDragX = event.getSceneX();
+        lastPreviewDragY = event.getSceneY();
+        event.consume();
+    }
+
+    private void handleMouseReleasedResize(MouseEvent event, boolean isTop, boolean isRight) {
+        if (!resizeDragging) {
+            return;
+        }
+        resizeDragging = false;
+        resizePreviewCreator.deleteResizePreview(element, preview);
+        var command = resizeCommandFactory.create(new ResizeCommandArgs(
+                isTop,
+                isRight,
+                resizeDragStartX,
+                resizeDragStartY,
+                event.getSceneX(),
+                event.getSceneY(),
+                element
+        ));
+        command.execute();
+        toggleShowResizeHandles(false);
+        toggleShowResizeHandles(true);
+        event.consume();
     }
 }

--- a/src/main/java/carleton/sysc4907/controller/element/ResizePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizePreviewCreator.java
@@ -1,0 +1,53 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.view.DiagramElement;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.Pane;
+import javafx.scene.shape.Rectangle;
+
+import java.io.IOException;
+
+/**
+ * Class responsible for creating and deleting previews when a diagram element is dragged to resize in the diagram.
+ */
+public class ResizePreviewCreator {
+
+    /**
+     * Constructs a new ResizePreviewCreator.
+     */
+    public ResizePreviewCreator() {
+
+    }
+
+    public Pane createResizePreview(DiagramElement element) {
+        FXMLLoader loader = new FXMLLoader();
+        loader.setLocation(ResizeHandleCreator.class.getResource("/carleton/sysc4907/view/element/ResizePreviewOutline.fxml"));
+        Pane preview = null;
+        try {
+            preview = loader.load();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        preview.setMaxWidth(element.getMaxWidth());
+        preview.setMaxHeight(element.getMaxHeight());
+        preview.setLayoutX(element.getLayoutX());
+        preview.setLayoutY(element.getLayoutY());
+        ((Pane) element.getParent()).getChildren().add(preview);
+        return preview;
+    }
+
+    /**
+     * Deletes the specified move preview from the scene.
+     * If the preview is null, does nothing.
+     * @param element the DiagramElement associated with the move preview to delete
+     * @param preview the preview to delete
+     */
+    public void deleteResizePreview(DiagramElement element, Pane preview) {
+        if (preview == null) {
+            return;
+        }
+        ((Pane) element.getParent()).getChildren().remove(preview);
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/ResizePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizePreviewCreator.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907.controller.element;
 
+import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
@@ -34,7 +35,8 @@ public class ResizePreviewCreator {
         preview.setMaxHeight(element.getMaxHeight());
         preview.setLayoutX(element.getLayoutX());
         preview.setLayoutY(element.getLayoutY());
-        ((Pane) element.getParent()).getChildren().add(preview);
+        Pane editingArea = EditingAreaProvider.getEditingArea();
+        editingArea.getChildren().add(preview);
         return preview;
     }
 

--- a/src/main/java/carleton/sysc4907/controller/element/UmlCommentController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/UmlCommentController.java
@@ -1,6 +1,7 @@
 package carleton.sysc4907.controller.element;
 
 import carleton.sysc4907.command.MoveCommandFactory;
+import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
@@ -32,8 +33,9 @@ public class UmlCommentController extends ResizableElementController {
             MovePreviewCreator previewCreator,
             MoveCommandFactory moveCommandFactory,
             DiagramModel diagramModel,
-            ResizeHandleCreator resizeHandleCreator) {
-        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator);
+            ResizeHandleCreator resizeHandleCreator,
+            ResizeCommandFactory resizeCommandFactory) {
+        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory);
     }
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/element/UmlCommentController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/UmlCommentController.java
@@ -34,8 +34,9 @@ public class UmlCommentController extends ResizableElementController {
             MoveCommandFactory moveCommandFactory,
             DiagramModel diagramModel,
             ResizeHandleCreator resizeHandleCreator,
+            ResizePreviewCreator resizePreviewCreator,
             ResizeCommandFactory resizeCommandFactory) {
-        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizeCommandFactory);
+        super(previewCreator, moveCommandFactory, diagramModel, resizeHandleCreator, resizePreviewCreator, resizeCommandFactory);
     }
 
     /**

--- a/src/main/resources/carleton/sysc4907/view/element/ResizePreviewOutline.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/ResizePreviewOutline.fxml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.Pane?>
+<Pane styleClass="resize-preview" prefWidth="Infinity" prefHeight="Infinity">
+</Pane>

--- a/src/main/resources/stylesheet/DiagramElementsStyle.css
+++ b/src/main/resources/stylesheet/DiagramElementsStyle.css
@@ -57,3 +57,12 @@
     -fx-fill: #EDEDED;
     -fx-stroke: #000000;
 }
+
+.resize-preview {
+    -fx-fill: #00000000;
+    -fx-stroke: red;
+    -fx-stroke-dash-array: 5;
+    -fx-stroke-width: 10;
+    -fx-border-color: #38B6FF;
+    -fx-border-style: dashed;
+}

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
@@ -1,0 +1,25 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.MoveCommandArgs;
+import carleton.sysc4907.command.args.ResizeCommandArgs;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ResizeCommandFactoryTest {
+
+    @Test
+    void createCommand() {
+        Pane mockNode = Mockito.mock(Pane.class);
+        ResizeCommandArgs args = new ResizeCommandArgs(true, true,
+                10, 0, 40, -30, mockNode);
+        ResizeCommandFactory factory = new ResizeCommandFactory();
+
+        var command = factory.create(args);
+
+        assertEquals(ResizeCommand.class, command.getClass());
+    }
+}

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
@@ -1,0 +1,53 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.MoveCommandArgs;
+import carleton.sysc4907.command.args.ResizeCommandArgs;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+
+public class ResizeCommandTest {
+
+    @Test
+    void executeResizeBottomRight() {
+        Pane mockNode = Mockito.mock(Pane.class);
+        Mockito.when(mockNode.getMaxHeight()).thenReturn(100.0);
+        Mockito.when(mockNode.getMaxWidth()).thenReturn(100.0);
+        doNothing().when(mockNode).setMaxWidth(130.0);
+        doNothing().when(mockNode).setMaxHeight(70.0);
+        ResizeCommandArgs args = new ResizeCommandArgs(false, true,
+                10, 0, 40, -30, mockNode);
+        ResizeCommand command = new ResizeCommand(args);
+
+        command.execute();
+
+        verify(mockNode, never()).setLayoutX(Mockito.anyDouble());
+        verify(mockNode, never()).setLayoutX(Mockito.anyDouble());
+        verify(mockNode).setMaxWidth(130.0);
+        verify(mockNode).setMaxHeight(70.0);
+    }
+
+    @Test
+    void executeResizeTopLeft() {
+        Pane mockNode = Mockito.mock(Pane.class);
+        Mockito.when(mockNode.getLayoutX()).thenReturn(0.0);
+        Mockito.when(mockNode.getLayoutY()).thenReturn(0.0);
+        Mockito.when(mockNode.getMaxHeight()).thenReturn(100.0);
+        Mockito.when(mockNode.getMaxWidth()).thenReturn(100.0);
+        doNothing().when(mockNode).setMaxWidth(130.0);
+        doNothing().when(mockNode).setMaxHeight(70.0);
+        ResizeCommandArgs args = new ResizeCommandArgs(true, false,
+                10, 0, -20, 30, mockNode);
+        ResizeCommand command = new ResizeCommand(args);
+
+        command.execute();
+
+        verify(mockNode).setLayoutX(-30.0);
+        verify(mockNode).setLayoutY(30.0);
+        verify(mockNode).setMaxWidth(130.0);
+        verify(mockNode).setMaxHeight(70.0);
+    }
+}

--- a/src/test/java/carleton/sysc4907/view/RectangleTest.java
+++ b/src/test/java/carleton/sysc4907/view/RectangleTest.java
@@ -1,8 +1,6 @@
 package carleton.sysc4907.view;
 
-import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.controller.element.RectangleController;
-import carleton.sysc4907.controller.element.ResizeHandleCreator;
 import javafx.stage.Stage;
 import org.testfx.framework.junit5.Start;
 
@@ -10,15 +8,10 @@ import java.io.IOException;
 
 public class RectangleTest extends ResizableElementTest {
 
-    private ResizeHandleCreator resizeHandleCreator;
-
-    private ResizeCommandFactory resizeCommandFactory;
 
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
-        resizeHandleCreator = new ResizeHandleCreator();
-        resizeCommandFactory = new ResizeCommandFactory();
         super.start(stage);
     }
 
@@ -29,6 +22,7 @@ public class RectangleTest extends ResizableElementTest {
                         moveCommandFactory,
                         diagramModel,
                         resizeHandleCreator,
+                        resizePreviewCreator,
                         resizeCommandFactory));
     }
 

--- a/src/test/java/carleton/sysc4907/view/RectangleTest.java
+++ b/src/test/java/carleton/sysc4907/view/RectangleTest.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907.view;
 
+import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.controller.element.RectangleController;
 import carleton.sysc4907.controller.element.ResizeHandleCreator;
 import javafx.stage.Stage;
@@ -11,17 +12,24 @@ public class RectangleTest extends ResizableElementTest {
 
     private ResizeHandleCreator resizeHandleCreator;
 
+    private ResizeCommandFactory resizeCommandFactory;
+
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
         resizeHandleCreator = new ResizeHandleCreator();
+        resizeCommandFactory = new ResizeCommandFactory();
         super.start(stage);
     }
 
     @Override
     protected void addInjectionMethods() {
         dependencyInjector.addInjectionMethod(RectangleController.class,
-                () -> new RectangleController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator));
+                () -> new RectangleController(movePreviewCreator,
+                        moveCommandFactory,
+                        diagramModel,
+                        resizeHandleCreator,
+                        resizeCommandFactory));
     }
 
     @Override

--- a/src/test/java/carleton/sysc4907/view/ResizableElementTest.java
+++ b/src/test/java/carleton/sysc4907/view/ResizableElementTest.java
@@ -1,6 +1,8 @@
 package carleton.sysc4907.view;
 
+import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.controller.element.ResizeHandleCreator;
+import carleton.sysc4907.controller.element.ResizePreviewCreator;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
@@ -14,9 +16,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class ResizableElementTest extends DiagramElementTest {
 
+    protected ResizeHandleCreator resizeHandleCreator;
+    protected ResizePreviewCreator resizePreviewCreator;
+    protected ResizeCommandFactory resizeCommandFactory;
+
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
+        resizeHandleCreator = new ResizeHandleCreator();
+        resizePreviewCreator = new ResizePreviewCreator();
+        resizeCommandFactory = new ResizeCommandFactory();
         super.start(stage);
     }
 

--- a/src/test/java/carleton/sysc4907/view/UmlCommentTest.java
+++ b/src/test/java/carleton/sysc4907/view/UmlCommentTest.java
@@ -1,8 +1,6 @@
 package carleton.sysc4907.view;
 
-import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.controller.element.EditableLabelController;
-import carleton.sysc4907.controller.element.ResizeHandleCreator;
 import carleton.sysc4907.controller.element.UmlCommentController;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
@@ -22,15 +20,9 @@ public class UmlCommentTest extends ResizableElementTest {
 
     private UmlCommentController controller;
 
-    private ResizeHandleCreator resizeHandleCreator;
-
-    private ResizeCommandFactory resizeCommandFactory;
-
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
-        resizeHandleCreator = new ResizeHandleCreator();
-        resizeCommandFactory = new ResizeCommandFactory();
         super.start(stage);
     }
 
@@ -41,6 +33,7 @@ public class UmlCommentTest extends ResizableElementTest {
                         moveCommandFactory,
                         diagramModel,
                         resizeHandleCreator,
+                        resizePreviewCreator,
                         resizeCommandFactory));
         dependencyInjector.addInjectionMethod(EditableLabelController.class,
                 EditableLabelController::new);

--- a/src/test/java/carleton/sysc4907/view/UmlCommentTest.java
+++ b/src/test/java/carleton/sysc4907/view/UmlCommentTest.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907.view;
 
+import carleton.sysc4907.command.ResizeCommandFactory;
 import carleton.sysc4907.controller.element.EditableLabelController;
 import carleton.sysc4907.controller.element.ResizeHandleCreator;
 import carleton.sysc4907.controller.element.UmlCommentController;
@@ -23,17 +24,24 @@ public class UmlCommentTest extends ResizableElementTest {
 
     private ResizeHandleCreator resizeHandleCreator;
 
+    private ResizeCommandFactory resizeCommandFactory;
+
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
         resizeHandleCreator = new ResizeHandleCreator();
+        resizeCommandFactory = new ResizeCommandFactory();
         super.start(stage);
     }
 
     @Override
     protected void addInjectionMethods() {
         dependencyInjector.addInjectionMethod(UmlCommentController.class,
-                () -> new UmlCommentController(movePreviewCreator, moveCommandFactory, diagramModel, resizeHandleCreator));
+                () -> new UmlCommentController(movePreviewCreator,
+                        moveCommandFactory,
+                        diagramModel,
+                        resizeHandleCreator,
+                        resizeCommandFactory));
         dependencyInjector.addInjectionMethod(EditableLabelController.class,
                 EditableLabelController::new);
     }


### PR DESCRIPTION
Resolves #25.
Preview is shown as a dotted-line blue rectangle, starting when the resize handle is dragged until it is released and the resize actually occurs.

There is a new resize command, and the code for ResizableElementController has also had significant changes.

While doing this, I realized that we should probably have a talk about command arguments, especially for the element we're affecting: that should probably be referred to by an ID since we're going to serialize this. Also talk about the use of commands for previews.

![image](https://github.com/Andrei486/uml-diagram-collab/assets/55627866/958a1c0c-60ab-4e6e-95e6-52a1972be2f3)
