### PR TITLE
Implement class dedicated to element creation

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -9,11 +9,15 @@ import carleton.sysc4907.command.MoveCommandFactory;
 import carleton.sysc4907.controller.*;
 import carleton.sysc4907.controller.element.*;
 import carleton.sysc4907.model.*;
+import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.FontOptionsFinder;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -39,8 +43,14 @@ public class DiagramEditorLoader {
         MovePreviewCreator movePreviewCreator = new MovePreviewCreator();
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
         DependencyInjector elementControllerInjector = new DependencyInjector();
+        ElementCreator elementCreator;
+        try {
+            elementCreator = new ElementCreator(elementControllerInjector, "/carleton/sysc4907/templates.xml");
+        } catch (ParserConfigurationException | SAXException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
         MoveCommandFactory moveCommandFactory = new MoveCommandFactory();
-        AddCommandFactory addCommandFactory = new AddCommandFactory(diagramModel, elementControllerInjector);
+        AddCommandFactory addCommandFactory = new AddCommandFactory(diagramModel, elementCreator);
         RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(diagramModel);
 
         // Add instantiation methods for the element injector, used to create diagram element controllers
@@ -63,7 +73,7 @@ public class DiagramEditorLoader {
         injector.addInjectionMethod(DiagramEditingAreaController.class,
                 () -> new DiagramEditingAreaController(diagramModel));
         injector.addInjectionMethod(ElementLibraryPanelController.class,
-                () -> new ElementLibraryPanelController(diagramModel, elementControllerInjector, addCommandFactory));
+                () -> new ElementLibraryPanelController(diagramModel, addCommandFactory, elementCreator));
 
         //Set up and show the scene
         Scene scene = new Scene(injector.load("view/DiagramEditorScreen.fxml"), 1280, 720);

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 public class DiagramEditorLoader {
 
+    private final String TEMPLATE_FILE_PATH = "/carleton/sysc4907/templates.xml";
+
     public void load(Stage stage, String username, String roomCode) throws IOException {
         //Create dependency injector to link models and controllers
         DependencyInjector injector = new DependencyInjector();
@@ -45,7 +47,7 @@ public class DiagramEditorLoader {
         DependencyInjector elementControllerInjector = new DependencyInjector();
         ElementCreator elementCreator;
         try {
-            elementCreator = new ElementCreator(elementControllerInjector, "/carleton/sysc4907/templates.xml");
+            elementCreator = new ElementCreator(elementControllerInjector, TEMPLATE_FILE_PATH);
         } catch (ParserConfigurationException | SAXException | URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -7,6 +7,7 @@ import carleton.sysc4907.command.MoveCommandFactory;
 import carleton.sysc4907.controller.*;
 import carleton.sysc4907.controller.element.*;
 import carleton.sysc4907.model.*;
+import carleton.sysc4907.processing.FontOptionsFinder;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 

--- a/src/main/java/carleton/sysc4907/command/AddCommand.java
+++ b/src/main/java/carleton/sysc4907/command/AddCommand.java
@@ -4,6 +4,7 @@ import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.Parent;
 import javafx.scene.layout.Pane;
@@ -17,25 +18,20 @@ public class AddCommand implements Command<AddCommandArgs> {
 
     private final AddCommandArgs args;
     private final DiagramModel diagramModel;
-    private final DependencyInjector elementInjector;
+    private final ElementCreator elementCreator;
 
-    public AddCommand(AddCommandArgs args, DiagramModel diagramModel, DependencyInjector elementInjector) {
+    public AddCommand(AddCommandArgs args, DiagramModel diagramModel, ElementCreator elementCreator) {
         this.args = args;
         this.diagramModel = diagramModel;
-        this.elementInjector = elementInjector;
+        this.elementCreator = elementCreator;
     }
 
     @Override
     public void execute() {
-        Parent obj;
         Pane editingArea = EditingAreaProvider.getEditingArea();
-        try {
-            obj = elementInjector.load(args.fxmlPath());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        editingArea.getChildren().add(obj);
-        DiagramElement element = (DiagramElement) obj;
+        DiagramElement element = elementCreator.create(args.elementType());
+        if (element == null) return; // If the type of element to create is not recognized
+        editingArea.getChildren().add(element);
         diagramModel.getElements().add(element);
     }
 }

--- a/src/main/java/carleton/sysc4907/command/AddCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/AddCommandFactory.java
@@ -3,17 +3,18 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementCreator;
 
 public class AddCommandFactory implements CommandFactory<Command<AddCommandArgs>, AddCommandArgs> {
     private final DiagramModel diagramModel;
-    private final DependencyInjector elementInjector;
+    private final ElementCreator elementCreator;
 
-    public AddCommandFactory(DiagramModel diagramModel, DependencyInjector elementInjector) {
+    public AddCommandFactory(DiagramModel diagramModel, ElementCreator elementCreator) {
         this.diagramModel = diagramModel;
-        this.elementInjector = elementInjector;
+        this.elementCreator = elementCreator;
     }
     @Override
     public Command create(AddCommandArgs args) {
-        return new AddCommand(args, diagramModel, elementInjector);
+        return new AddCommand(args, diagramModel, elementCreator);
     }
 }

--- a/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
@@ -2,7 +2,7 @@ package carleton.sysc4907.command.args;
 
 /**
  * Arguments for the add command
- * @param fxmlPath the path to the FXML file for the element
+ * @param elementType the type of element to create
  */
-public record AddCommandArgs(String fxmlPath) {
+public record AddCommandArgs(String elementType) {
 }

--- a/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
+++ b/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
@@ -3,6 +3,7 @@ package carleton.sysc4907.controller;
 import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.command.AddCommandFactory;
 import carleton.sysc4907.command.args.AddCommandArgs;
+import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.fxml.FXML;
@@ -29,18 +30,21 @@ public class ElementLibraryPanelController {
     private TitledPane titledPane;
 
     private final DiagramModel diagramModel;
-    private final DependencyInjector elementInjector;
     private Pane editingArea = null;
+
+    private final ElementCreator elementCreator;
 
     /**
      * Constructs a new ElementLibraryPanelController.
      * @param diagramModel the DiagramModel for the current diagram
-     * @param elementInjector the DependencyInjector used to load new diagram elements from FXML
      */
-    public ElementLibraryPanelController(DiagramModel diagramModel, DependencyInjector elementInjector, AddCommandFactory addCommandFactory) {
+    public ElementLibraryPanelController(
+            DiagramModel diagramModel,
+            AddCommandFactory addCommandFactory,
+            ElementCreator elementCreator) {
         this.diagramModel = diagramModel;
-        this.elementInjector = elementInjector;
         this.addCommandFactory = addCommandFactory;
+        this.elementCreator = elementCreator;
     }
 
     /**
@@ -54,27 +58,21 @@ public class ElementLibraryPanelController {
     @FXML
     public void initialize() {
         List<Button> buttons = new LinkedList<>();
-        buttons.add(createAddButton(
-                "Rectangle",
-                "/carleton/sysc4907/view/element/Rectangle.fxml"
-        ));
-        buttons.add(createAddButton(
-                "UML Comment",
-                "/carleton/sysc4907/view/element/UmlComment.fxml"
-        ));
+        for (String type : elementCreator.getRegisteredTypes()) {
+            buttons.add(createAddButton(type));
+        }
         elementsPane.getChildren().addAll(buttons);
     }
 
     /**
      * Create a button to add a specific kind of element to the diagram.
-     * @param elementName the human-readable name of the element
-     * @param fxmlPath the path of the FXML defining the element
+     * @param elementName the name of the element, recognizable by the ElementCreator
      * @return a Button that, when clicked, will instantiate the element and add it to the diagram
      */
-    private Button createAddButton(String elementName, String fxmlPath) {
+    private Button createAddButton(String elementName) {
         Button button = new Button(elementName);
         button.setOnAction(actionEvent -> {
-            AddCommandArgs args = new AddCommandArgs(fxmlPath);
+            AddCommandArgs args = new AddCommandArgs(elementName);
             var command = addCommandFactory.create(args);
             command.execute();
 

--- a/src/main/java/carleton/sysc4907/model/TextFormattingModel.java
+++ b/src/main/java/carleton/sysc4907/model/TextFormattingModel.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907.model;
 
+import carleton.sysc4907.processing.FontOptionsFinder;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -75,7 +75,7 @@ public class ElementCreator {
      * @param type name of the element type
      * @return file path of the template used to create elements of the given type
      */
-    private String resolveTypeToTemplate(String type) {
+    public String resolveTypeToTemplate(String type) {
         return this.typeTemplateMap.get(type);
     }
 }

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -13,6 +13,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.HashMap;
 
 public class ElementCreator {
@@ -76,6 +77,15 @@ public class ElementCreator {
      * @return file path of the template used to create elements of the given type
      */
     public String resolveTypeToTemplate(String type) {
+        System.out.println(type + " " + this.typeTemplateMap.get(type));
         return this.typeTemplateMap.get(type);
+    }
+
+    /**
+     * Gets all registered element types that this object can create.
+     * @return collection containing all valid element types
+     */
+    public Collection<String> getRegisteredTypes() {
+        return this.typeTemplateMap.keySet();
     }
 }

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -16,6 +16,9 @@ import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashMap;
 
+/**
+ * Class responsible for creating diagram elements using FXML templates.
+ */
 public class ElementCreator {
 
     private final DependencyInjector elementInjector;
@@ -23,6 +26,11 @@ public class ElementCreator {
 
     private final HashMap<String, String> typeTemplateMap;
 
+    /**
+     * Constructs a new ElementCreator.
+     * @param elementInjector the DependencyInjector to use for creating controllers
+     * @param templateFilePath the XML file that contains mappings from element type to FXML template
+     */
     public ElementCreator(DependencyInjector elementInjector, String templateFilePath) throws
             ParserConfigurationException,
             IOException,

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -1,0 +1,81 @@
+package carleton.sysc4907.processing;
+
+import carleton.sysc4907.DependencyInjector;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.scene.Parent;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+
+public class ElementCreator {
+
+    private final DependencyInjector elementInjector;
+    private final String templateFilePath;
+
+    private final HashMap<String, String> typeTemplateMap;
+
+    public ElementCreator(DependencyInjector elementInjector, String templateFilePath) throws
+            ParserConfigurationException,
+            IOException,
+            SAXException,
+            URISyntaxException {
+        this.elementInjector = elementInjector;
+        this.templateFilePath = templateFilePath;
+        this.typeTemplateMap = new HashMap<>();
+        populateTypeTemplateMap();
+    }
+
+    /**
+     * Creates a new diagram element of the given type.
+     * @param type the type of diagram element to create
+     * @return the created diagram element, or null if none could be created
+     */
+    public DiagramElement create(String type) {
+        String path = resolveTypeToTemplate(type);
+        if (path == null) { // Type not recognized
+            return null;
+        }
+        Parent obj;
+        try {
+            obj = elementInjector.load(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        DiagramElement element = (DiagramElement) obj;
+        return element;
+    }
+
+    /**
+     * Populates the type-template map using the file path provided in the constructor.
+     */
+    private void populateTypeTemplateMap() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = builder.parse(new File(ElementCreator.class.getResource(this.templateFilePath).toURI()));
+        doc.getDocumentElement().normalize();
+        NodeList nodeList = doc.getElementsByTagName("template");
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            var node = nodeList.item(i);
+            var attributes = node.getAttributes();
+            String type = attributes.getNamedItem("type").getNodeValue();
+            String fxmlPath = attributes.getNamedItem("fxml").getNodeValue();
+            this.typeTemplateMap.put(type, fxmlPath);
+        }
+    }
+
+    /**
+     * Gets the file path of the FXML template associated with the given type of element.
+     * @param type name of the element type
+     * @return file path of the template used to create elements of the given type
+     */
+    private String resolveTypeToTemplate(String type) {
+        return this.typeTemplateMap.get(type);
+    }
+}

--- a/src/main/java/carleton/sysc4907/processing/FontOptionsFinder.java
+++ b/src/main/java/carleton/sysc4907/processing/FontOptionsFinder.java
@@ -1,4 +1,4 @@
-package carleton.sysc4907.model;
+package carleton.sysc4907.processing;
 
 import javafx.scene.text.Font;
 

--- a/src/main/resources/carleton/sysc4907/templates.xml
+++ b/src/main/resources/carleton/sysc4907/templates.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<templates>
+    <!-- FXML paths must be specified relative to the resources directory, with a leading slash.-->
+    <template type="rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>
+    <template type="uml-comment" fxml="/carleton/sysc4907/view/element/UmlComment.fxml"/>
+</templates>

--- a/src/main/resources/carleton/sysc4907/templates.xml
+++ b/src/main/resources/carleton/sysc4907/templates.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <templates>
     <!-- FXML paths must be specified relative to the resources directory, with a leading slash.-->
-    <template type="rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>
-    <template type="uml-comment" fxml="/carleton/sysc4907/view/element/UmlComment.fxml"/>
+    <!-- Element type names should be human-readable: they are displayed on the UI! -->
+    <template type="Rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>
+    <template type="UML Comment" fxml="/carleton/sysc4907/view/element/UmlComment.fxml"/>
 </templates>

--- a/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
@@ -3,6 +3,7 @@ import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementCreator;
 import javafx.scene.Node;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -14,9 +15,9 @@ public class AddCommandFactoryTest {
     void createCommand() {
         String fxmlPath = "TestPath";
         DiagramModel diagramModel = new DiagramModel();
-        DependencyInjector mockElementInjector = Mockito.mock(DependencyInjector.class);
+        ElementCreator mockElementCreator = Mockito.mock(ElementCreator.class);
         AddCommandArgs args = new AddCommandArgs(fxmlPath);
-        AddCommandFactory factory = new AddCommandFactory(diagramModel, mockElementInjector);
+        AddCommandFactory factory = new AddCommandFactory(diagramModel, mockElementCreator);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/AddCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandTest.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
+import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.view.DiagramElement;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ public class AddCommandTest {
     private Pane mockEditingArea;
 
     @Mock
-    private DependencyInjector mockDependencyInjector;
+    private ElementCreator mockElementCreator;
 
     @Mock
     private DiagramElement mockDiagramElement;
@@ -70,11 +71,11 @@ public class AddCommandTest {
                     thenReturn(true);
             Mockito.when(mockElementsList.add(any(DiagramElement.class)))
                     .thenReturn(true);
-            Mockito.when(mockDependencyInjector.load(any(String.class)))
+            Mockito.when(mockElementCreator.create("testType"))
                     .thenReturn(mockDiagramElement);
 
-            AddCommandArgs args = new AddCommandArgs("testPath");
-            AddCommand command = new AddCommand(args, mockDiagramModel, mockDependencyInjector);
+            AddCommandArgs args = new AddCommandArgs("testType");
+            AddCommand command = new AddCommand(args, mockDiagramModel, mockElementCreator);
 
             //execute
             command.execute();
@@ -82,8 +83,6 @@ public class AddCommandTest {
             //verify
             verify(mockNodesList).add(any(Node.class));
             verify(mockElementsList).add(any(DiagramElement.class));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
 
     }

--- a/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
@@ -2,10 +2,15 @@ package carleton.sysc4907.processing;
 
 import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.view.DiagramElement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 public class ElementCreatorTest {
@@ -14,8 +19,36 @@ public class ElementCreatorTest {
     @Mock
     private DependencyInjector mockElementInjector;
 
+    @Mock
+    private DiagramElement element1;
+
+    @Mock
+    private DiagramElement element2;
+
     @Test
-    public void getElementTemplates() throws Exception {
+    public void resolveElementTemplates() throws Exception {
+        // Test that the constructor does not throw an error for a valid XML file
         ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH);
+
+        assertEquals(
+                "/carleton/sysc4907/view/element/Rectangle.fxml",
+                elementCreator.resolveTypeToTemplate("rectangle"));
+        assertEquals(
+                "/carleton/sysc4907/view/element/UmlComment.fxml",
+                elementCreator.resolveTypeToTemplate("uml-comment"));
+        assertNull(elementCreator.resolveTypeToTemplate("nonexistent"));
+    }
+
+    @Test
+    public void createElements() throws Exception {
+        // Test that the constructor does not throw an error for a valid XML file
+        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH);
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
+
+        assertEquals(element1, elementCreator.create("rectangle"));
+        assertEquals(element2, elementCreator.create("uml-comment"));
+        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/Rectangle.fxml");
+        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/UmlComment.fxml");
     }
 }

--- a/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
@@ -1,0 +1,21 @@
+package carleton.sysc4907.processing;
+
+import carleton.sysc4907.DependencyInjector;
+import carleton.sysc4907.processing.ElementCreator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ElementCreatorTest {
+
+    private final String TEST_FILE_PATH = "/carleton/sysc4907/model/templates.xml";
+    @Mock
+    private DependencyInjector mockElementInjector;
+
+    @Test
+    public void getElementTemplates() throws Exception {
+        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH);
+    }
+}

--- a/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
@@ -1,9 +1,11 @@
 package carleton.sysc4907.view;
 
 import carleton.sysc4907.DependencyInjector;
+import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.AddCommandFactory;
 import carleton.sysc4907.controller.ElementLibraryPanelController;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementCreator;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -12,16 +14,16 @@ import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
 import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -38,44 +40,56 @@ public class ElementLibraryPanelTest {
     private ObservableList<DiagramElement> mockElementsList;
 
     @Mock
-    private ObservableList<DiagramElement> mockSelectedElementsList;
-
-    @Mock
     private ObservableList<Node> mockNodesList;
 
     @Mock
     private Pane editingArea;
 
     @Mock
-    private DependencyInjector mockDependencyInjector;
+    private ElementCreator mockElementCreator;
+
+    @Mock
+    private DiagramElement mockDiagramElement;
+
     @Start
     private void start(Stage stage) throws IOException {
-        Mockito.when(mockDependencyInjector.load(any(String.class))).thenReturn(new DiagramElement());
-        DependencyInjector injector = new DependencyInjector();
-        AddCommandFactory addCommandFactory = new AddCommandFactory(mockDiagramModel, mockDependencyInjector);
-        injector.addInjectionMethod(ElementLibraryPanelController.class,
-                () -> {
-                    var controller = new ElementLibraryPanelController(mockDiagramModel, mockDependencyInjector, addCommandFactory);
-                    controller.setEditingArea(editingArea);
-                    return controller;
-                });
-        Scene scene = new Scene(injector.load("view/ElementLibraryPanel.fxml"));
-        stage.setScene(scene);
-        stage.show();
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(editingArea);
+            Mockito.when(editingArea.getChildren()).thenReturn(mockNodesList);
+            Collection<String> types = new HashSet<>();
+            types.add("rectangleType");
+            Mockito.when(mockElementCreator.getRegisteredTypes()).thenReturn(types);
+            DependencyInjector injector = new DependencyInjector();
+            AddCommandFactory addCommandFactory = new AddCommandFactory(mockDiagramModel, mockElementCreator);
+            injector.addInjectionMethod(ElementLibraryPanelController.class,
+                    () -> {
+                        var controller = new ElementLibraryPanelController(
+                                mockDiagramModel,
+                                addCommandFactory,
+                                mockElementCreator);
+                        controller.setEditingArea(editingArea);
+                        return controller;
+                    });
+            Scene scene = new Scene(injector.load("view/ElementLibraryPanel.fxml"));
+            stage.setScene(scene);
+            stage.show();
+        }
     }
 
     @Test
     void addRectangle(FxRobot robot) {
+        EditingAreaProvider.init(editingArea);
         Mockito.when(mockDiagramModel.getElements()).thenReturn(mockElementsList);
-        Mockito.when(mockDiagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
         Mockito.when(mockElementsList.add(any(DiagramElement.class))).thenReturn(true);
-        doNothing().when(mockSelectedElementsList).clear();
         Mockito.when(editingArea.getChildren()).thenReturn(mockNodesList);
         Mockito.when(mockNodesList.add(any(Node.class))).thenReturn(true);
+        Mockito.when(mockElementCreator.create("rectangleType"))
+                .thenReturn(mockDiagramElement);
 
         robot.clickOn("#elementsPane .button");
 
         Mockito.verify(mockElementsList).add(any(DiagramElement.class));
         Mockito.verify(mockNodesList).add(any(Node.class));
+        EditingAreaProvider.init(null);
     }
 }

--- a/src/test/resources/carleton/sysc4907/model/templates.xml
+++ b/src/test/resources/carleton/sysc4907/model/templates.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<templates>
+    <!-- FXML paths must be specified relative to the resources directory, with a leading slash.-->
+    <template type="rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>
+    <template type="uml-comment" fxml="/carleton/sysc4907/view/element/UmlComment.fxml"/>
+</templates>


### PR DESCRIPTION
Resolves #34.

The main addition is the ElementCreator class along with the template.xml file that it uses. This new utility class is used in the add command to create an element instead of directly calling the dependency injector - it allows other classes to ignore the actual paths for the FXML templates.

Once we do IDs we will add the ID to newly created elements inside the ElementCreator.