### PR TITLE
Implement element IDs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,5 @@ jobs:
       with:
         java-version: '17.0.9'
         distribution: 'temurin'
-        cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '17.0.9'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17.0.9'
+        java-version: '17'
         distribution: 'temurin'
+        cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -11,6 +11,7 @@ import carleton.sysc4907.controller.*;
 import carleton.sysc4907.controller.element.*;
 import carleton.sysc4907.model.*;
 import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.processing.FontOptionsFinder;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -41,9 +42,10 @@ public class DiagramEditorLoader {
         User hostUser = userFactory.createHostUser(username);
         SessionModel sessionModel = new SessionModel(roomCode, hostUser);
         guestUsers.forEach(sessionModel::addUser);
+        ElementIdManager elementIdManager = new ElementIdManager(sessionModel);
         TextFormattingModel textFormattingModel = new TextFormattingModel(fontOptionsFinder);
         DiagramModel diagramModel = new DiagramModel();
-        MovePreviewCreator movePreviewCreator = new MovePreviewCreator();
+        MovePreviewCreator movePreviewCreator = new MovePreviewCreator(elementIdManager);
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
         ResizePreviewCreator resizePreviewCreator = new ResizePreviewCreator();
         DependencyInjector elementControllerInjector = new DependencyInjector();
@@ -53,7 +55,7 @@ public class DiagramEditorLoader {
         } catch (ParserConfigurationException | SAXException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
-        MoveCommandFactory moveCommandFactory = new MoveCommandFactory();
+        MoveCommandFactory moveCommandFactory = new MoveCommandFactory(elementIdManager);
         ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory();
         AddCommandFactory addCommandFactory = new AddCommandFactory(diagramModel, elementCreator);
         RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(diagramModel);
@@ -80,7 +82,7 @@ public class DiagramEditorLoader {
         injector.addInjectionMethod(DiagramEditingAreaController.class,
                 () -> new DiagramEditingAreaController(diagramModel));
         injector.addInjectionMethod(ElementLibraryPanelController.class,
-                () -> new ElementLibraryPanelController(diagramModel, addCommandFactory, elementCreator));
+                () -> new ElementLibraryPanelController(diagramModel, addCommandFactory, elementCreator, elementIdManager));
 
         //Set up and show the scene
         Scene scene = new Scene(injector.load("view/DiagramEditorScreen.fxml"), 1280, 720);

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -47,7 +47,7 @@ public class DiagramEditorLoader {
         DiagramModel diagramModel = new DiagramModel();
         MovePreviewCreator movePreviewCreator = new MovePreviewCreator(elementIdManager);
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
-        ResizePreviewCreator resizePreviewCreator = new ResizePreviewCreator();
+        ResizePreviewCreator resizePreviewCreator = new ResizePreviewCreator(elementIdManager);
         DependencyInjector elementControllerInjector = new DependencyInjector();
         ElementCreator elementCreator;
         try {
@@ -56,9 +56,9 @@ public class DiagramEditorLoader {
             throw new RuntimeException(e);
         }
         MoveCommandFactory moveCommandFactory = new MoveCommandFactory(elementIdManager);
-        ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory();
+        ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory(elementIdManager);
         AddCommandFactory addCommandFactory = new AddCommandFactory(diagramModel, elementCreator);
-        RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(diagramModel);
+        RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(diagramModel, elementIdManager);
 
         // Add instantiation methods for the element injector, used to create diagram element controllers
         elementControllerInjector.addInjectionMethod(RectangleController.class,

--- a/src/main/java/carleton/sysc4907/command/AddCommand.java
+++ b/src/main/java/carleton/sysc4907/command/AddCommand.java
@@ -29,7 +29,7 @@ public class AddCommand implements Command<AddCommandArgs> {
     @Override
     public void execute() {
         Pane editingArea = EditingAreaProvider.getEditingArea();
-        DiagramElement element = elementCreator.create(args.elementType());
+        DiagramElement element = elementCreator.create(args.elementType(), args.elementId());
         if (element == null) return; // If the type of element to create is not recognized
         editingArea.getChildren().add(element);
         diagramModel.getElements().add(element);

--- a/src/main/java/carleton/sysc4907/command/MoveCommand.java
+++ b/src/main/java/carleton/sysc4907/command/MoveCommand.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
 
 /**
  * Command for the move element operation
@@ -9,14 +10,17 @@ import carleton.sysc4907.model.DiagramModel;
 public class MoveCommand implements Command<MoveCommandArgs> {
 
     private final MoveCommandArgs args;
+    private final ElementIdManager elementIdManager;
 
-    public MoveCommand(MoveCommandArgs args) {
+    public MoveCommand(MoveCommandArgs args, ElementIdManager elementIdManager) {
         this.args = args;
+        this.elementIdManager = elementIdManager;
     }
 
     @Override
     public void execute() {
-        var element = args.element();
+        var element = elementIdManager.getElementById(args.elementId());
+        if (element == null) return;
         element.setLayoutX(args.endX() - args.startX());
         element.setLayoutY(args.endY() - args.startY());
     }

--- a/src/main/java/carleton/sysc4907/command/MoveCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/MoveCommandFactory.java
@@ -2,14 +2,18 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
 
 public class MoveCommandFactory implements CommandFactory<Command<MoveCommandArgs>, MoveCommandArgs> {
 
-    public MoveCommandFactory() {
+    private final ElementIdManager elementIdManager;
+
+    public MoveCommandFactory(ElementIdManager elementIdManager) {
+        this.elementIdManager = elementIdManager;
     }
 
     @Override
     public Command create(MoveCommandArgs args) {
-        return new MoveCommand(args);
+        return new MoveCommand(args, elementIdManager);
     }
 }

--- a/src/main/java/carleton/sysc4907/command/RemoveCommand.java
+++ b/src/main/java/carleton/sysc4907/command/RemoveCommand.java
@@ -3,7 +3,12 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
+import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.layout.Pane;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Command for the remove element operation. Multiple remove operations can be done with one command
@@ -13,17 +18,30 @@ public class RemoveCommand implements Command<RemoveCommandArgs> {
     private final RemoveCommandArgs args;
     private final DiagramModel diagramModel;
 
-    public RemoveCommand(RemoveCommandArgs args, DiagramModel diagramModel) {
+    private final ElementIdManager elementIdManager;
+
+    public RemoveCommand(RemoveCommandArgs args, DiagramModel diagramModel, ElementIdManager elementIdManager) {
         this.args = args;
         this.diagramModel = diagramModel;
+        this.elementIdManager = elementIdManager;
 
     }
 
     @Override
     public void execute() {
         Pane editingArea = EditingAreaProvider.getEditingArea();
-        editingArea.getChildren().removeAll(args.elements());
-        diagramModel.getElements().removeAll(args.elements());
+        List<DiagramElement> elements = new LinkedList<>();
+        for (long id : args.elementIds()) {
+            var element = (DiagramElement) elementIdManager.getElementById(id);
+            if (element != null) {
+                elements.add(element);
+            }
+        }
+        if (elements.isEmpty()) {
+            return;
+        }
+        editingArea.getChildren().removeAll(elements);
+        diagramModel.getElements().removeAll(elements);
         diagramModel.getSelectedElements().clear();
     }
 

--- a/src/main/java/carleton/sysc4907/command/RemoveCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/RemoveCommandFactory.java
@@ -3,16 +3,19 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
 
 public class RemoveCommandFactory implements CommandFactory<Command<RemoveCommandArgs>, RemoveCommandArgs> {
     private final DiagramModel diagramModel;
+    private final ElementIdManager elementIdManager;
 
-    public RemoveCommandFactory(DiagramModel diagramModel) {
+    public RemoveCommandFactory(DiagramModel diagramModel, ElementIdManager elementIdManager) {
         this.diagramModel = diagramModel;
+        this.elementIdManager = elementIdManager;
     }
 
     @Override
     public Command create(RemoveCommandArgs args) {
-        return new RemoveCommand(args, diagramModel);
+        return new RemoveCommand(args, diagramModel, elementIdManager);
     }
 }

--- a/src/main/java/carleton/sysc4907/command/ResizeCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommand.java
@@ -1,20 +1,26 @@
 package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.ResizeCommandArgs;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.layout.Pane;
 
 public class ResizeCommand implements Command<ResizeCommandArgs> {
 
     private final ResizeCommandArgs args;
+    private final ElementIdManager elementIdManager;
 
-    public ResizeCommand(ResizeCommandArgs args) {
+    public ResizeCommand(ResizeCommandArgs args, ElementIdManager elementIdManager) {
         this.args = args;
+        this.elementIdManager = elementIdManager;
     }
 
     @Override
     public void execute() {
-        var element = args.element();
+        Pane element = (Pane) elementIdManager.getElementById(args.elementId());
+        if (element == null) {
+            return;
+        }
         var dragStartX = args.dragStartX();
         var dragStartY = args.dragStartY();
         var dragEndX = args.dragEndX();

--- a/src/main/java/carleton/sysc4907/command/ResizeCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommandFactory.java
@@ -1,11 +1,17 @@
 package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.ResizeCommandArgs;
+import carleton.sysc4907.processing.ElementIdManager;
 
 public class ResizeCommandFactory implements CommandFactory<Command<ResizeCommandArgs>, ResizeCommandArgs> {
 
+    private final ElementIdManager elementIdManager;
+
+    public ResizeCommandFactory(ElementIdManager elementIdManager) {
+        this.elementIdManager = elementIdManager;
+    }
     @Override
     public Command create(ResizeCommandArgs args) {
-        return new ResizeCommand(args);
+        return new ResizeCommand(args, elementIdManager);
     }
 }

--- a/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
@@ -1,8 +1,10 @@
 package carleton.sysc4907.command.args;
 
+import java.io.Serializable;
+
 /**
  * Arguments for the add command
  * @param elementType the type of element to create
  */
-public record AddCommandArgs(String elementType, long elementId) {
+public record AddCommandArgs(String elementType, long elementId) implements Serializable {
 }

--- a/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
@@ -4,5 +4,5 @@ package carleton.sysc4907.command.args;
  * Arguments for the add command
  * @param elementType the type of element to create
  */
-public record AddCommandArgs(String elementType) {
+public record AddCommandArgs(String elementType, long elementId) {
 }

--- a/src/main/java/carleton/sysc4907/command/args/MoveCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/MoveCommandArgs.java
@@ -8,8 +8,8 @@ import javafx.scene.Node;
  * @param startY the starting Y coordinate of the element
  * @param endX the ending X coordinate of the element
  * @param endY the ending Y coordinate of the element
- * @param element the element to be moved
+ * @param elementId the ID of the element to be moved
  */
-public record MoveCommandArgs(double startX, double startY, double endX, double endY, Node element) {
+public record MoveCommandArgs(double startX, double startY, double endX, double endY, long elementId) {
 
 }

--- a/src/main/java/carleton/sysc4907/command/args/MoveCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/MoveCommandArgs.java
@@ -2,6 +2,8 @@ package carleton.sysc4907.command.args;
 
 import javafx.scene.Node;
 
+import java.io.Serializable;
+
 /**
  * Arguments for the move command
  * @param startX the starting X coordinate of the element
@@ -10,6 +12,6 @@ import javafx.scene.Node;
  * @param endY the ending Y coordinate of the element
  * @param elementId the ID of the element to be moved
  */
-public record MoveCommandArgs(double startX, double startY, double endX, double endY, long elementId) {
+public record MoveCommandArgs(double startX, double startY, double endX, double endY, long elementId) implements Serializable {
 
 }

--- a/src/main/java/carleton/sysc4907/command/args/RemoveCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/RemoveCommandArgs.java
@@ -1,10 +1,10 @@
 package carleton.sysc4907.command.args;
 
-import java.util.List;
+import java.io.Serializable;
 
 /**
  * Arguments for the remove command
  * @param elementIds the IDs for the elements to remove
  */
-public record RemoveCommandArgs(List<Long> elementIds) {
+public record RemoveCommandArgs(long[] elementIds) implements Serializable {
 }

--- a/src/main/java/carleton/sysc4907/command/args/RemoveCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/RemoveCommandArgs.java
@@ -1,13 +1,10 @@
 package carleton.sysc4907.command.args;
 
-import carleton.sysc4907.view.DiagramElement;
-import javafx.scene.Node;
-
 import java.util.List;
 
 /**
  * Arguments for the remove command
- * @param elements the elements to remove
+ * @param elementIds the IDs for the elements to remove
  */
-public record RemoveCommandArgs(List<DiagramElement> elements) {
+public record RemoveCommandArgs(List<Long> elementIds) {
 }

--- a/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
@@ -2,12 +2,14 @@ package carleton.sysc4907.command.args;
 
 import javafx.scene.layout.Pane;
 
+import java.io.Serializable;
+
 public record ResizeCommandArgs(boolean isTopAnchor,
                                 boolean isRightAnchor,
                                 double dragStartX,
                                 double dragStartY,
                                 double dragEndX,
                                 double dragEndY,
-                                long elementId) {
+                                long elementId) implements Serializable {
 
 }

--- a/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
@@ -8,6 +8,6 @@ public record ResizeCommandArgs(boolean isTopAnchor,
                                 double dragStartY,
                                 double dragEndX,
                                 double dragEndY,
-                                Pane element) {
+                                long elementId) {
 
 }

--- a/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
+++ b/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
@@ -51,7 +51,7 @@ public class DiagramMenuBarController {
     public void deleteSelectedElements() {
         List<Long> toDelete = diagramModel.getSelectedElements().stream().map(DiagramElement::getElementId).toList();
         if (!toDelete.isEmpty()) {
-            RemoveCommandArgs args = new RemoveCommandArgs(toDelete);
+            RemoveCommandArgs args = new RemoveCommandArgs(toDelete.stream().mapToLong(l -> l).toArray());
             var command = removeCommandFactory.create(args);
             command.execute();
         }

--- a/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
+++ b/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
@@ -49,7 +49,7 @@ public class DiagramMenuBarController {
      * Deletes all selected elements from the diagram.
      */
     public void deleteSelectedElements() {
-        List<DiagramElement> toDelete = diagramModel.getSelectedElements();
+        List<Long> toDelete = diagramModel.getSelectedElements().stream().map(DiagramElement::getElementId).toList();
         if (!toDelete.isEmpty()) {
             RemoveCommandArgs args = new RemoveCommandArgs(toDelete);
             var command = removeCommandFactory.create(args);

--- a/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
+++ b/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
@@ -4,6 +4,7 @@ import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.command.AddCommandFactory;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.fxml.FXML;
@@ -32,6 +33,7 @@ public class ElementLibraryPanelController {
     private final DiagramModel diagramModel;
 
     private final ElementCreator elementCreator;
+    private final ElementIdManager elementIdManager;
 
     /**
      * Constructs a new ElementLibraryPanelController.
@@ -40,10 +42,12 @@ public class ElementLibraryPanelController {
     public ElementLibraryPanelController(
             DiagramModel diagramModel,
             AddCommandFactory addCommandFactory,
-            ElementCreator elementCreator) {
+            ElementCreator elementCreator,
+            ElementIdManager elementIdManager) {
         this.diagramModel = diagramModel;
         this.addCommandFactory = addCommandFactory;
         this.elementCreator = elementCreator;
+        this.elementIdManager = elementIdManager;
     }
 
     @FXML
@@ -63,7 +67,7 @@ public class ElementLibraryPanelController {
     private Button createAddButton(String elementName) {
         Button button = new Button(elementName);
         button.setOnAction(actionEvent -> {
-            AddCommandArgs args = new AddCommandArgs(elementName);
+            AddCommandArgs args = new AddCommandArgs(elementName, elementIdManager.getNewId());
             var command = addCommandFactory.create(args);
             command.execute();
 

--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -142,7 +142,7 @@ public abstract class DiagramElementController {
             MoveCommandArgs args = new MoveCommandArgs(
                     dragStartX, dragStartY,
                     dragEndX, dragEndY,
-                    preview);
+                    (Long) preview.getUserData());
             var command = moveCommandFactory.create(args);
             command.execute();
         }
@@ -160,7 +160,7 @@ public abstract class DiagramElementController {
         MoveCommandArgs args = new MoveCommandArgs(
                 dragStartX, dragStartY,
                 dragEndX, dragEndY,
-                element);
+                element.getElementId());
         var command = moveCommandFactory.create(args);
         command.execute();
     }

--- a/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
@@ -1,6 +1,7 @@
 package carleton.sysc4907.controller.element;
 
 import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
@@ -11,11 +12,13 @@ import javafx.scene.layout.Pane;
  */
 public class MovePreviewCreator {
 
+    private final ElementIdManager elementIdManager;
+
     /**
      * Constructs a new MovePreviewCreator.
      */
-    public MovePreviewCreator() {
-
+    public MovePreviewCreator(ElementIdManager elementIdManager) {
+        this.elementIdManager = elementIdManager;
     }
 
     /**
@@ -28,8 +31,8 @@ public class MovePreviewCreator {
     public ImageView createMovePreview(DiagramElement element, double dragStartX, double dragStartY) {
         // create preview
         WritableImage img = element.snapshot(null, new WritableImage(
-                (int) element.getBoundsInParent().getWidth(),
-                (int) element.getBoundsInParent().getHeight()));
+                (int) element.getBoundsInParent().getWidth() + 2,
+                (int) element.getBoundsInParent().getHeight() + 2));
 
         ImageView preview = new ImageView(img);
         preview.setOpacity(0.5);
@@ -38,6 +41,7 @@ public class MovePreviewCreator {
 
         Pane editingArea = EditingAreaProvider.getEditingArea();
         editingArea.getChildren().add(preview);
+        preview.setUserData(elementIdManager.getNewId());
         return preview;
     }
 

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -26,6 +26,8 @@ public abstract class ResizableElementController extends DiagramElementControlle
     private final ResizePreviewCreator resizePreviewCreator;
     private Pane preview = null;
 
+
+
     private double resizeDragStartX = 0;
     private double resizeDragStartY = 0;
     private double lastPreviewDragX = 0;
@@ -129,7 +131,7 @@ public abstract class ResizableElementController extends DiagramElementControlle
                     resizeDragStartY,
                     event.getSceneX(),
                     event.getSceneY(),
-                    preview
+                    (long) preview.getUserData()
             );
             var command = resizeCommandFactory.create(args);
             command.execute();
@@ -152,7 +154,7 @@ public abstract class ResizableElementController extends DiagramElementControlle
                 resizeDragStartY,
                 event.getSceneX(),
                 event.getSceneY(),
-                element
+                element.getElementId()
         ));
         command.execute();
         toggleShowResizeHandles(false);

--- a/src/main/java/carleton/sysc4907/controller/element/ResizePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizePreviewCreator.java
@@ -1,6 +1,7 @@
 package carleton.sysc4907.controller.element;
 
 import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
@@ -15,11 +16,13 @@ import java.io.IOException;
  */
 public class ResizePreviewCreator {
 
+    private final ElementIdManager elementIdManager;
+
     /**
      * Constructs a new ResizePreviewCreator.
      */
-    public ResizePreviewCreator() {
-
+    public ResizePreviewCreator(ElementIdManager elementIdManager) {
+        this.elementIdManager = elementIdManager;
     }
 
     public Pane createResizePreview(DiagramElement element) {
@@ -37,6 +40,7 @@ public class ResizePreviewCreator {
         preview.setLayoutY(element.getLayoutY());
         Pane editingArea = EditingAreaProvider.getEditingArea();
         editingArea.getChildren().add(preview);
+        preview.setUserData(elementIdManager.getNewId());
         return preview;
     }
 

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -87,7 +87,6 @@ public class ElementCreator {
      * @return file path of the template used to create elements of the given type
      */
     public String resolveTypeToTemplate(String type) {
-        System.out.println(type + " " + this.typeTemplateMap.get(type));
         return this.typeTemplateMap.get(type);
     }
 

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -45,9 +45,10 @@ public class ElementCreator {
     /**
      * Creates a new diagram element of the given type.
      * @param type the type of diagram element to create
+     * @param elementId the ID to assign to the element
      * @return the created diagram element, or null if none could be created
      */
-    public DiagramElement create(String type) {
+    public DiagramElement create(String type, long elementId) {
         String path = resolveTypeToTemplate(type);
         if (path == null) { // Type not recognized
             return null;
@@ -59,6 +60,7 @@ public class ElementCreator {
             throw new RuntimeException(e);
         }
         DiagramElement element = (DiagramElement) obj;
+        element.setUserData(elementId);
         return element;
     }
 

--- a/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
@@ -1,0 +1,72 @@
+package carleton.sysc4907.processing;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.model.SessionModel;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+
+import java.util.Random;
+
+/**
+ * A class that manages the active editing area's elements, allowing searches for elements via their ID.
+ * Note that elements in this case may represent DiagramElements, or other JavaFX entities such as previews, or
+ * sub-elements of DiagramElements.
+ * This is different from the DiagramModel, which manages only DiagramElements for the purposes of selecting them,
+ * saving them, etc.
+ */
+public class ElementIdManager {
+
+    private final SessionModel sessionModel;
+
+    public ElementIdManager(SessionModel sessionModel) {
+        this.sessionModel = sessionModel;
+    }
+
+    /**
+     * Returns a new ID that can be allocated to a newly created element or sub-element. This ID
+     * is guaranteed to not be used yet on any element currently in the diagram.
+     * @return a new unique ID for the element
+     */
+    public Long getNewId() {
+        Random rng = new Random();
+        long id;
+        do {
+            id = rng.nextLong() >> 8 << 8; // The shifts will unset the last 8 bits, so we can use them for user ID
+            id = id | (sessionModel.getLocalUser().getId() & 0xFF); // Set the last 8 bits to the last 8 bits of the user's ID
+        } while (existsWithId(id)); // Chance of collisions is low enough that one attempt is practically always enough
+        return id;
+    }
+
+    /**
+     * Checks whether there is already an element in the diagram with the given ID.
+     * @param id the ID to check
+     * @return true if such an element exists, false otherwise
+     */
+    public boolean existsWithId(Long id) {
+        return getElementById(id) != null;
+    }
+
+    /**
+     * Gets the element in the diagram with the given ID, if it exists.
+     * @param id the ID to get the element for
+     * @return the element as a Node if it exists, or null if there is no element with the ID
+     */
+    public Node getElementById(Long id) {
+        Parent parent = EditingAreaProvider.getEditingArea();
+        return getElementByIdInParent(parent, id);
+    }
+
+    private Node getElementByIdInParent(Parent parent, Long id) {
+        for (Node n : parent.getChildrenUnmodifiable()) {
+            if (id.equals(n.getUserData())) {
+                return n;
+            }
+            // Recursively search inside non-leaf nodes
+            if (n instanceof Parent) {
+                Node resultInNode = getElementByIdInParent((Parent) n, id);
+                if (resultInNode != null) return resultInNode;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/carleton/sysc4907/view/DiagramElement.java
+++ b/src/main/java/carleton/sysc4907/view/DiagramElement.java
@@ -7,4 +7,7 @@ import javafx.scene.layout.Pane;
  */
 public class DiagramElement extends Pane {
 
+    public long getElementId() {
+        return (Long) getUserData();
+    }
 }

--- a/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
@@ -16,7 +16,7 @@ public class AddCommandFactoryTest {
         String fxmlPath = "TestPath";
         DiagramModel diagramModel = new DiagramModel();
         ElementCreator mockElementCreator = Mockito.mock(ElementCreator.class);
-        AddCommandArgs args = new AddCommandArgs(fxmlPath);
+        AddCommandArgs args = new AddCommandArgs(fxmlPath, 0);
         AddCommandFactory factory = new AddCommandFactory(diagramModel, mockElementCreator);
 
         var command = factory.create(args);

--- a/src/test/java/carleton/sysc4907/command/AddCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandTest.java
@@ -74,7 +74,7 @@ public class AddCommandTest {
             Mockito.when(mockElementCreator.create(eq("testType"), anyLong()))
                     .thenReturn(mockDiagramElement);
 
-            AddCommandArgs args = new AddCommandArgs(eq("testType"), anyLong());
+            AddCommandArgs args = new AddCommandArgs("testType", 2L);
             AddCommand command = new AddCommand(args, mockDiagramModel, mockElementCreator);
 
             //execute

--- a/src/test/java/carleton/sysc4907/command/AddCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandTest.java
@@ -71,10 +71,10 @@ public class AddCommandTest {
                     thenReturn(true);
             Mockito.when(mockElementsList.add(any(DiagramElement.class)))
                     .thenReturn(true);
-            Mockito.when(mockElementCreator.create("testType"))
+            Mockito.when(mockElementCreator.create(eq("testType"), anyLong()))
                     .thenReturn(mockDiagramElement);
 
-            AddCommandArgs args = new AddCommandArgs("testType");
+            AddCommandArgs args = new AddCommandArgs(eq("testType"), anyLong());
             AddCommand command = new AddCommand(args, mockDiagramModel, mockElementCreator);
 
             //execute

--- a/src/test/java/carleton/sysc4907/command/MoveCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/MoveCommandFactoryTest.java
@@ -1,21 +1,28 @@
 package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.MoveCommandArgs;
-import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
 import javafx.scene.Node;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doNothing;
 
+@ExtendWith(MockitoExtension.class)
 public class MoveCommandFactoryTest {
+
+    @Mock
+    private Node mockNode;
+    @Mock
+    private ElementIdManager mockElementIdManager;
 
     @Test
     void createCommand() {
-        Node mockNode = Mockito.mock(Node.class);
-        MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, mockNode);
-        MoveCommandFactory factory = new MoveCommandFactory();
+        long testId = 12L;
+        MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, testId);
+        MoveCommandFactory factory = new MoveCommandFactory(mockElementIdManager);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/MoveCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/MoveCommandTest.java
@@ -1,22 +1,32 @@
 package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.MoveCommandArgs;
-import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
 import javafx.scene.Node;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class MoveCommandTest {
+
+    @Mock
+    private Node mockNode;
+    @Mock
+    private ElementIdManager mockElementIdManager;
 
     @Test
     void executeMoves() {
-        Node mockNode = Mockito.mock(Node.class);
+        long testId = 12L;
         doNothing().when(mockNode).setLayoutX(30);
         doNothing().when(mockNode).setLayoutY(-30);
-        MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, mockNode);
-        MoveCommand command = new MoveCommand(args);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+
+        MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, testId);
+        MoveCommand command = new MoveCommand(args, mockElementIdManager);
 
         command.execute();
 

--- a/src/test/java/carleton/sysc4907/command/RemoveCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/RemoveCommandFactoryTest.java
@@ -1,29 +1,29 @@
 package carleton.sysc4907.command;
 
-import carleton.sysc4907.DependencyInjector;
-import carleton.sysc4907.command.args.AddCommandArgs;
-import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
-import carleton.sysc4907.view.DiagramElement;
-import javafx.scene.Node;
+import carleton.sysc4907.processing.ElementIdManager;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doNothing;
 
+@ExtendWith(MockitoExtension.class)
 public class RemoveCommandFactoryTest {
 
+    @Mock
+    private ElementIdManager mockElementIdManager;
     @Test
     void createCommand() {
-        List<DiagramElement> elems = new ArrayList<>();
-        RemoveCommandArgs args = new RemoveCommandArgs(elems);
+        List<Long> ids = new ArrayList<>();
+        RemoveCommandArgs args = new RemoveCommandArgs(ids);
         DiagramModel diagramModel = new DiagramModel();
-        RemoveCommandFactory factory = new RemoveCommandFactory(diagramModel);
+        RemoveCommandFactory factory = new RemoveCommandFactory(diagramModel, mockElementIdManager);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/RemoveCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/RemoveCommandFactoryTest.java
@@ -20,7 +20,7 @@ public class RemoveCommandFactoryTest {
     private ElementIdManager mockElementIdManager;
     @Test
     void createCommand() {
-        List<Long> ids = new ArrayList<>();
+        long[] ids = new long[0];
         RemoveCommandArgs args = new RemoveCommandArgs(ids);
         DiagramModel diagramModel = new DiagramModel();
         RemoveCommandFactory factory = new RemoveCommandFactory(diagramModel, mockElementIdManager);

--- a/src/test/java/carleton/sysc4907/command/RemoveCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/RemoveCommandTest.java
@@ -87,9 +87,7 @@ public class RemoveCommandTest {
             List<DiagramElement> elemList = new ArrayList<>();
             elemList.add(mockDiagramElement1);
             elemList.add(mockDiagramElement2);
-            List<Long> idList = new ArrayList<>();
-            idList.add(mockDiagramElement1.getElementId());
-            idList.add(mockDiagramElement2.getElementId());
+            long[] idList = new long[] {mockDiagramElement1.getElementId(), mockDiagramElement2.getElementId()};
 
             RemoveCommandArgs args = new RemoveCommandArgs(idList);
             RemoveCommand command = new RemoveCommand(args, mockDiagramModel, mockElementIdManager);

--- a/src/test/java/carleton/sysc4907/command/RemoveCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/RemoveCommandTest.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +53,9 @@ public class RemoveCommandTest {
     @Mock
     private DiagramElement mockDiagramElement2;
 
+    @Mock
+    private ElementIdManager mockElementIdManager;
+
     @Test
     void executeRemoves() {
     /* test that these are called:
@@ -61,8 +65,14 @@ public class RemoveCommandTest {
         diagramModel.getSelectedElements().clear();
     */
         //setup
+        long id1 = 1L;
+        long id2 = 2L;
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            Mockito.when(mockDiagramElement1.getElementId()).thenReturn(id1);
+            Mockito.when(mockDiagramElement2.getElementId()).thenReturn(id2);
+            Mockito.when(mockElementIdManager.getElementById(id1)).thenReturn(mockDiagramElement1);
+            Mockito.when(mockElementIdManager.getElementById(id2)).thenReturn(mockDiagramElement2);
             Mockito.when(mockDiagramModel.getElements())
                     .thenReturn(mockElementsList);
             Mockito.when(mockDiagramModel.getSelectedElements())
@@ -77,9 +87,12 @@ public class RemoveCommandTest {
             List<DiagramElement> elemList = new ArrayList<>();
             elemList.add(mockDiagramElement1);
             elemList.add(mockDiagramElement2);
+            List<Long> idList = new ArrayList<>();
+            idList.add(mockDiagramElement1.getElementId());
+            idList.add(mockDiagramElement2.getElementId());
 
-            RemoveCommandArgs args = new RemoveCommandArgs(elemList);
-            RemoveCommand command = new RemoveCommand(args, mockDiagramModel);
+            RemoveCommandArgs args = new RemoveCommandArgs(idList);
+            RemoveCommand command = new RemoveCommand(args, mockDiagramModel, mockElementIdManager);
 
             //execute
             command.execute();

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
@@ -2,21 +2,32 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.command.args.ResizeCommandArgs;
+import carleton.sysc4907.processing.ElementIdManager;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(MockitoExtension.class)
 public class ResizeCommandFactoryTest {
+
+    @Mock
+    private Node mockNode;
+    @Mock
+    private ElementIdManager mockElementIdManager;
 
     @Test
     void createCommand() {
+        long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
         ResizeCommandArgs args = new ResizeCommandArgs(true, true,
-                10, 0, 40, -30, mockNode);
-        ResizeCommandFactory factory = new ResizeCommandFactory();
+                10, 0, 40, -30, testId);
+        ResizeCommandFactory factory = new ResizeCommandFactory(mockElementIdManager);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
@@ -1,26 +1,37 @@
 package carleton.sysc4907.command;
 
-import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.command.args.ResizeCommandArgs;
+import carleton.sysc4907.processing.ElementIdManager;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 public class ResizeCommandTest {
+
+    @Mock
+    private Node mockNode;
+    @Mock
+    private ElementIdManager mockElementIdManager;
 
     @Test
     void executeResizeBottomRight() {
+        long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
         Mockito.when(mockNode.getMaxHeight()).thenReturn(100.0);
         Mockito.when(mockNode.getMaxWidth()).thenReturn(100.0);
         doNothing().when(mockNode).setMaxWidth(130.0);
         doNothing().when(mockNode).setMaxHeight(70.0);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(false, true,
-                10, 0, 40, -30, mockNode);
-        ResizeCommand command = new ResizeCommand(args);
+                10, 0, 40, -30, testId);
+        ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
 
         command.execute();
 
@@ -32,6 +43,7 @@ public class ResizeCommandTest {
 
     @Test
     void executeResizeTopLeft() {
+        long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
         Mockito.when(mockNode.getLayoutX()).thenReturn(0.0);
         Mockito.when(mockNode.getLayoutY()).thenReturn(0.0);
@@ -39,9 +51,10 @@ public class ResizeCommandTest {
         Mockito.when(mockNode.getMaxWidth()).thenReturn(100.0);
         doNothing().when(mockNode).setMaxWidth(130.0);
         doNothing().when(mockNode).setMaxHeight(70.0);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(true, false,
-                10, 0, -20, 30, mockNode);
-        ResizeCommand command = new ResizeCommand(args);
+                10, 0, -20, 30, testId);
+        ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
 
         command.execute();
 

--- a/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
@@ -46,8 +46,8 @@ public class ElementCreatorTest {
         Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
         Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
 
-        assertEquals(element1, elementCreator.create("rectangle"));
-        assertEquals(element2, elementCreator.create("uml-comment"));
+        assertEquals(element1, elementCreator.create("rectangle", 0L));
+        assertEquals(element2, elementCreator.create("uml-comment", 0L));
         Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/Rectangle.fxml");
         Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/UmlComment.fxml");
     }

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerFunctionalTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerFunctionalTest.java
@@ -1,0 +1,30 @@
+package carleton.sysc4907.processing;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.model.PermissionLevel;
+import carleton.sysc4907.model.SessionModel;
+import carleton.sysc4907.model.User;
+import javafx.collections.FXCollections;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ElementIdManagerFunctionalTest {
+
+    @Test
+    public void testGetNewId() {
+        SessionModel sessionModel = new SessionModel("12345678ABCD", new User(1, "TEST", PermissionLevel.HOST));
+        Pane editingArea = new Pane();
+        EditingAreaProvider.init(editingArea);
+        ElementIdManager elementIdManager = new ElementIdManager(sessionModel);
+        var id = elementIdManager.getNewId();
+        var expectedLastBits = id & 0xFF;
+        assertEquals(expectedLastBits, id & 0xFF);
+    }
+}

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.LinkedList;
@@ -48,9 +49,6 @@ public class ElementIdManagerTest {
     @BeforeEach
     public void setup() {
         elementIdManager = new ElementIdManager(mockSessionModel);
-    }
-
-    private void initMocks() {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
@@ -61,7 +59,6 @@ public class ElementIdManagerTest {
 
     @Test
     public void testGetNewId() {
-        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
@@ -73,7 +70,6 @@ public class ElementIdManagerTest {
 
     @Test
     public void getIdExists() {
-        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -85,7 +81,6 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdExists() {
-        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -97,7 +92,6 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdExistNested() {
-        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -109,7 +103,6 @@ public class ElementIdManagerTest {
 
     @Test
     public void getIdDoesNotExist() {
-        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -121,7 +114,6 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdDoesNotExist() {
-        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -1,0 +1,123 @@
+package carleton.sysc4907.processing;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.model.SessionModel;
+import carleton.sysc4907.model.User;
+import javafx.beans.property.SimpleListProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ElementIdManagerTest {
+
+    @Mock
+    private SessionModel mockSessionModel;
+
+    @Mock
+    private User mockUser;
+
+    @Mock
+    private Parent mockParent;
+    @Mock
+    private Node mockNode;
+    @Mock
+    private Pane mockEditingArea;
+
+    private String testUserId = "testlongid";
+    private long testNodeId = 1L;
+
+    private ElementIdManager elementIdManager;
+
+    @BeforeEach
+    public void setup() {
+        lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
+        lenient().when(mockUser.getUsername()).thenReturn(testUserId);
+        lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
+        var nodesList = new LinkedList<Node>();
+        nodesList.add(mockNode);
+        lenient().when(mockParent.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(nodesList));
+        elementIdManager = new ElementIdManager(mockSessionModel);
+    }
+
+    @Test
+    public void testGetNewId() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(new SimpleListProperty<>());
+            var id = elementIdManager.getNewId();
+            var expectedLastBits = id & 0xFF;
+            assertEquals(expectedLastBits, id & 0xFF);
+        }
+    }
+
+    @Test
+    public void getIdExists() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            assertTrue(elementIdManager.existsWithId(testNodeId));
+        }
+    }
+
+    @Test
+    public void getElementByIdExists() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            assertEquals(mockNode, elementIdManager.getElementById(testNodeId));
+        }
+    }
+
+    @Test
+    public void getElementByIdExistNested() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockParent);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            assertEquals(mockNode, elementIdManager.getElementById(testNodeId));
+        }
+    }
+
+    @Test
+    public void getIdDoesNotExist() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            assertFalse(elementIdManager.existsWithId(201L));
+        }
+    }
+
+    @Test
+    public void getElementByIdDoesNotExist() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            assertNull(elementIdManager.getElementById(201L));
+        }
+    }
+}

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -3,14 +3,11 @@ package carleton.sysc4907.processing;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.model.SessionModel;
 import carleton.sysc4907.model.User;
-import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.layout.Pane;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -47,8 +44,7 @@ public class ElementIdManagerTest {
 
     private ElementIdManager elementIdManager;
 
-    @BeforeEach
-    public void setup() {
+    private void setup() {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
@@ -60,6 +56,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void testGetNewId() {
+        setup();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
@@ -71,6 +68,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getIdExists() {
+        setup();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -82,6 +80,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdExists() {
+        setup();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -93,6 +92,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdExistNested() {
+        setup();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -104,6 +104,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getIdDoesNotExist() {
+        setup();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -115,6 +116,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdDoesNotExist() {
+        setup();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -9,6 +9,7 @@ import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +47,7 @@ public class ElementIdManagerTest {
 
     private ElementIdManager elementIdManager;
 
-    @BeforeEach
+    @BeforeAll
     public void setup() {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -39,24 +40,28 @@ public class ElementIdManagerTest {
     @Mock
     private Pane mockEditingArea;
 
-    private String testUserId = "testlongid";
+    private final String testUserId = "testlongid";
     private final long testNodeId = 1L;
 
     private ElementIdManager elementIdManager;
 
-    private void setup() {
+    @BeforeEach
+    public void setup() {
+        elementIdManager = new ElementIdManager(mockSessionModel);
+    }
+
+    private void initMocks() {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
         var nodesList = new LinkedList<Node>();
         nodesList.add(mockNode);
         lenient().when(mockParent.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(nodesList));
-        elementIdManager = new ElementIdManager(mockSessionModel);
     }
 
     @Test
     public void testGetNewId() {
-        setup();
+        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
@@ -68,7 +73,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getIdExists() {
-        setup();
+        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -80,7 +85,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdExists() {
-        setup();
+        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -92,7 +97,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdExistNested() {
-        setup();
+        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -104,7 +109,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getIdDoesNotExist() {
-        setup();
+        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
@@ -116,7 +121,7 @@ public class ElementIdManagerTest {
 
     @Test
     public void getElementByIdDoesNotExist() {
-        setup();
+        initMocks();
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.LinkedList;
@@ -52,9 +51,6 @@ public class ElementIdManagerTest {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
-        var nodesList = new LinkedList<Node>();
-        nodesList.add(mockNode);
-        lenient().when(mockParent.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(nodesList));
     }
 
     @Test
@@ -91,12 +87,15 @@ public class ElementIdManagerTest {
     }
 
     @Test
-    public void getElementByIdExistNested() {
+    public void getElementByIdExistsNested() {
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
             ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
             nodes.add(mockParent);
             when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            var nodesList = new LinkedList<Node>();
+            nodesList.add(mockNode);
+            when(mockParent.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(nodesList));
             assertEquals(mockNode, elementIdManager.getElementById(testNodeId));
         }
     }

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -53,16 +53,16 @@ public class ElementIdManagerTest {
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
     }
 
-    @Test
-    public void testGetNewId() {
-        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
-            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
-            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
-            var id = elementIdManager.getNewId();
-            var expectedLastBits = id & 0xFF;
-            assertEquals(expectedLastBits, id & 0xFF);
-        }
-    }
+//    @Test
+//    public void testGetNewId() {
+//        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+//            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+//            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+//            var id = elementIdManager.getNewId();
+//            var expectedLastBits = id & 0xFF;
+//            assertEquals(expectedLastBits, id & 0xFF);
+//        }
+//    }
 
     @Test
     public void getIdExists() {

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -53,17 +53,6 @@ public class ElementIdManagerTest {
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
     }
 
-//    @Test
-//    public void testGetNewId() {
-//        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
-//            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
-//            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
-//            var id = elementIdManager.getNewId();
-//            var expectedLastBits = id & 0xFF;
-//            assertEquals(expectedLastBits, id & 0xFF);
-//        }
-//    }
-
     @Test
     public void getIdExists() {
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -47,7 +47,7 @@ public class ElementIdManagerTest {
 
     private ElementIdManager elementIdManager;
 
-    @BeforeAll
+    @BeforeEach
     public void setup() {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);
@@ -62,7 +62,7 @@ public class ElementIdManagerTest {
     public void testGetNewId() {
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
             utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
-            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(new SimpleListProperty<>());
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
             var id = elementIdManager.getNewId();
             var expectedLastBits = id & 0xFF;
             assertEquals(expectedLastBits, id & 0xFF);

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -40,7 +40,7 @@ public class ElementIdManagerTest {
     private Pane mockEditingArea;
 
     private String testUserId = "testlongid";
-    private long testNodeId = 1L;
+    private final long testNodeId = 1L;
 
     private ElementIdManager elementIdManager;
 

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -34,8 +34,10 @@ public class ElementIdManagerTest {
 
     @Mock
     private Parent mockParent;
+
     @Mock
     private Node mockNode;
+
     @Mock
     private Pane mockEditingArea;
 

--- a/src/test/java/carleton/sysc4907/view/DiagramElementTest.java
+++ b/src/test/java/carleton/sysc4907/view/DiagramElementTest.java
@@ -56,6 +56,8 @@ public abstract class DiagramElementTest {
 
     protected DiagramElement element;
 
+    protected long testId = 12L;
+
     @Mock
     protected ElementIdManager elementIdManager;
 
@@ -67,8 +69,6 @@ public abstract class DiagramElementTest {
     @Start
     protected void start(Stage stage) throws IOException {
         diagramModel = new DiagramModel();
-        Mockito.when(movePreviewCreator.createMovePreview(any(DiagramElement.class), any(Double.class), any(Double.class))).thenReturn(new ImageView());
-        doNothing().when(movePreviewCreator).deleteMovePreview(any(), any());
         moveCommandFactory = new MoveCommandFactory(elementIdManager);
         initializeDependencyInjector();
         // Load the scroll pane and get the editing area from it
@@ -76,6 +76,7 @@ public abstract class DiagramElementTest {
         editingArea = (Pane) root.getContent();
         // Load the element and add it
         element = loadElement();
+        element.setUserData(12L);
         editingArea.getChildren().add(element);
         diagramModel.getElements().add(element);
         // Show the scene
@@ -139,6 +140,7 @@ public abstract class DiagramElementTest {
      */
     @Test
     protected void testDragMove(FxRobot robot) {
+        Mockito.when(elementIdManager.getElementById(testId)).thenReturn(element);
         var x = element.getLayoutX();
         var y = element.getLayoutY();
         robot.drag(element).dropBy(100, 150);

--- a/src/test/java/carleton/sysc4907/view/DiagramElementTest.java
+++ b/src/test/java/carleton/sysc4907/view/DiagramElementTest.java
@@ -6,6 +6,7 @@ import carleton.sysc4907.controller.DiagramEditingAreaController;
 import carleton.sysc4907.controller.element.MovePreviewCreator;
 import carleton.sysc4907.model.DiagramModel;
 import carleton.sysc4907.controller.element.RectangleController;
+import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.TextFormattingModel;
 import javafx.collections.ObservableList;
@@ -20,7 +21,9 @@ import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
@@ -35,12 +38,14 @@ import static org.mockito.Mockito.doNothing;
 /**
  * Base class for UI tests on diagram elements within an editing area.
  */
+@ExtendWith(MockitoExtension.class)
 @ExtendWith(ApplicationExtension.class)
 public abstract class DiagramElementTest {
 
     protected final String SELECTED_STYLE_CLASS = "selected-element";
     protected DiagramModel diagramModel;
 
+    @Mock
     protected MovePreviewCreator movePreviewCreator;
 
     protected MoveCommandFactory moveCommandFactory;
@@ -51,6 +56,9 @@ public abstract class DiagramElementTest {
 
     protected DiagramElement element;
 
+    @Mock
+    protected ElementIdManager elementIdManager;
+
     /**
      * Sets up the scene before each test, loading an editing area and adding the element inside it.
      * @param stage Stage used for testing
@@ -59,10 +67,9 @@ public abstract class DiagramElementTest {
     @Start
     protected void start(Stage stage) throws IOException {
         diagramModel = new DiagramModel();
-        movePreviewCreator = Mockito.mock(MovePreviewCreator.class);
         Mockito.when(movePreviewCreator.createMovePreview(any(DiagramElement.class), any(Double.class), any(Double.class))).thenReturn(new ImageView());
         doNothing().when(movePreviewCreator).deleteMovePreview(any(), any());
-        moveCommandFactory = new MoveCommandFactory();
+        moveCommandFactory = new MoveCommandFactory(elementIdManager);
         initializeDependencyInjector();
         // Load the scroll pane and get the editing area from it
         ScrollPane root = (ScrollPane) dependencyInjector.load("view/DiagramEditingArea.fxml");

--- a/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
@@ -6,6 +6,7 @@ import carleton.sysc4907.command.AddCommandFactory;
 import carleton.sysc4907.controller.ElementLibraryPanelController;
 import carleton.sysc4907.model.DiagramModel;
 import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.processing.ElementIdManager;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -51,6 +52,9 @@ public class ElementLibraryPanelTest {
     @Mock
     private DiagramElement mockDiagramElement;
 
+    @Mock
+    private ElementIdManager mockElementIdManager;
+
     @Start
     private void start(Stage stage) throws IOException {
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
@@ -66,7 +70,8 @@ public class ElementLibraryPanelTest {
                         var controller = new ElementLibraryPanelController(
                                 mockDiagramModel,
                                 addCommandFactory,
-                                mockElementCreator);
+                                mockElementCreator,
+                                mockElementIdManager);
                         return controller;
                     });
             Scene scene = new Scene(injector.load("view/ElementLibraryPanel.fxml"));
@@ -79,13 +84,15 @@ public class ElementLibraryPanelTest {
 
     @Test
     void addRectangle(FxRobot robot) {
+        long testId = 12L;
         EditingAreaProvider.init(editingArea);
         Mockito.when(mockDiagramModel.getElements()).thenReturn(mockElementsList);
         Mockito.when(mockElementsList.add(any(DiagramElement.class))).thenReturn(true);
         Mockito.when(editingArea.getChildren()).thenReturn(mockNodesList);
         Mockito.when(mockNodesList.add(any(Node.class))).thenReturn(true);
-        Mockito.when(mockElementCreator.create("rectangleType"))
+        Mockito.when(mockElementCreator.create("rectangleType", testId))
                 .thenReturn(mockDiagramElement);
+        Mockito.when(mockElementIdManager.getNewId()).thenReturn(testId);
 
         robot.clickOn("#elementsPane .button");
 

--- a/src/test/java/carleton/sysc4907/view/ResizableElementTest.java
+++ b/src/test/java/carleton/sysc4907/view/ResizableElementTest.java
@@ -6,6 +6,8 @@ import carleton.sysc4907.controller.element.ResizePreviewCreator;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.Start;
 
@@ -17,15 +19,18 @@ import static org.junit.jupiter.api.Assertions.*;
 public abstract class ResizableElementTest extends DiagramElementTest {
 
     protected ResizeHandleCreator resizeHandleCreator;
+
+    @Mock
     protected ResizePreviewCreator resizePreviewCreator;
     protected ResizeCommandFactory resizeCommandFactory;
+
+    protected long testResizePreviewId = 14L;
 
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
         resizeHandleCreator = new ResizeHandleCreator();
-        resizePreviewCreator = new ResizePreviewCreator();
-        resizeCommandFactory = new ResizeCommandFactory();
+        resizeCommandFactory = new ResizeCommandFactory(elementIdManager);
         super.start(stage);
     }
 
@@ -35,6 +40,7 @@ public abstract class ResizableElementTest extends DiagramElementTest {
      */
     @Test
     protected void testResizeOnHandleDragBottomRight(FxRobot robot) {
+        Mockito.when(elementIdManager.getElementById(testId)).thenReturn(element);
         var selectedElements = diagramModel.getSelectedElements();
         assertEquals(0, selectedElements.size());
         assertFalse(element.getStyleClass().contains(SELECTED_STYLE_CLASS));
@@ -69,6 +75,7 @@ public abstract class ResizableElementTest extends DiagramElementTest {
      */
     @Test
     protected void testResizeOnHandleDragTopLeftMinSize(FxRobot robot) {
+        Mockito.when(elementIdManager.getElementById(testId)).thenReturn(element);
         var selectedElements = diagramModel.getSelectedElements();
         assertEquals(0, selectedElements.size());
         assertFalse(element.getStyleClass().contains(SELECTED_STYLE_CLASS));


### PR DESCRIPTION
Resolves #33.

Done:
- Implement element ID manager and search by ID
- Update the add command to use IDs (and give the new element one)
- Update the move command to target an ID not an element
- Update the resize command to target an ID not an element
- Update the remove command to target IDs not elements
- Unit tests for the element ID manager