### PR TITLE
Add support for sub-element IDs

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -51,7 +51,7 @@ public class DiagramEditorLoader {
         DependencyInjector elementControllerInjector = new DependencyInjector();
         ElementCreator elementCreator;
         try {
-            elementCreator = new ElementCreator(elementControllerInjector, TEMPLATE_FILE_PATH);
+            elementCreator = new ElementCreator(elementControllerInjector, TEMPLATE_FILE_PATH, elementIdManager);
         } catch (ParserConfigurationException | SAXException | URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/carleton/sysc4907/command/AddCommand.java
+++ b/src/main/java/carleton/sysc4907/command/AddCommand.java
@@ -1,15 +1,11 @@
 package carleton.sysc4907.command;
 
-import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.model.DiagramModel;
 import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.view.DiagramElement;
-import javafx.scene.Parent;
 import javafx.scene.layout.Pane;
-
-import java.io.IOException;
 
 /**
  * Command for the add element operation
@@ -29,7 +25,7 @@ public class AddCommand implements Command<AddCommandArgs> {
     @Override
     public void execute() {
         Pane editingArea = EditingAreaProvider.getEditingArea();
-        DiagramElement element = elementCreator.create(args.elementType(), args.elementId());
+        DiagramElement element = elementCreator.create(args.elementType(), args.elementId(), true);
         if (element == null) return; // If the type of element to create is not recognized
         editingArea.getChildren().add(element);
         diagramModel.getElements().add(element);

--- a/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
+++ b/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
@@ -67,7 +67,8 @@ public class ElementLibraryPanelController {
     private Button createAddButton(String elementName) {
         Button button = new Button(elementName);
         button.setOnAction(actionEvent -> {
-            AddCommandArgs args = new AddCommandArgs(elementName, elementIdManager.getNewId());
+            int subElementCount = elementCreator.countIdSubElements(elementName);
+            AddCommandArgs args = new AddCommandArgs(elementName, elementIdManager.getNewIdRange(subElementCount));
             var command = addCommandFactory.create(args);
             command.execute();
 

--- a/src/main/java/carleton/sysc4907/controller/element/EditableLabelController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/EditableLabelController.java
@@ -115,7 +115,11 @@ public class EditableLabelController {
         editableText.setVisible(editable);
         editableText.setDisable(!editable);
         editableText.setEditable(editable);
-        if (editable) editableText.selectAll();
+        if (editable) {
+            editableText.setText(label.getText());
+            editableText.selectAll();
+
+        }
         label.setText(editableText.getText());
     }
 }

--- a/src/main/java/carleton/sysc4907/processing/ElementCreator.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementCreator.java
@@ -129,7 +129,9 @@ public class ElementCreator {
      */
     public int countIdSubElements(String type) {
         if (this.subElementCountMap.isEmpty()) populateSubElementCountMap();
-        return this.subElementCountMap.get(type);
+        var result = this.subElementCountMap.get(type);
+        if (result == null) throw new IllegalArgumentException(type + " is not a recognized element type");
+        return result;
     }
 
     private List<Node> getSubElements(Parent parent) {

--- a/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
@@ -31,7 +31,7 @@ public class ElementIdManager {
         Random rng = new Random();
         long id;
         do {
-            id = rng.nextLong() >> 8 << 8; // The shifts will unset the last 8 bits, so we can use them for user ID
+            id = (rng.nextLong() >> 8) << 8; // The shifts will unset the last 8 bits, so we can use them for user ID
             id = id | (sessionModel.getLocalUser().getId() & 0xFF); // Set the last 8 bits to the last 8 bits of the user's ID
         } while (existsWithId(id)); // Chance of collisions is low enough that one attempt is practically always enough
         return id;

--- a/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
@@ -38,6 +38,39 @@ public class ElementIdManager {
     }
 
     /**
+     * Returns a new ID that can be allocated to a newly created element with `length` sub-elements. This ID
+     * is guaranteed to not be used yet on any element currently in the diagram, and the following `length` IDs are
+     * also guaranteed to not be used yet, so they can be applied to sub-elements sequentially.
+     * @param length the number of IDs past the first that need to be reserved for sub-elements
+     * @return a new unique ID for the element
+     */
+    public Long getNewIdRange(int length) {
+        long id = 0L;
+        boolean foundId = false;
+        while (!foundId) {
+            id = getNewId();
+            boolean noIdConflicts = true;
+            for (int i = 1; i <= length; i++) {
+                if (existsWithId(getNextId(id, i))) {
+                    noIdConflicts = false;
+                }
+            }
+            if (noIdConflicts) foundId = true;
+        }
+        return id;
+    }
+
+    /**
+     * Returns the next ID for the same user. Used for getting consecutive IDs for sub-elements.
+     * @param id the previous ID
+     * @param steps the number of "next" steps to take from the original ID
+     * @return the new ID
+     */
+    public Long getNextId(long id, int steps) {
+        return id + steps * 0x100L;
+    }
+
+    /**
      * Checks whether there is already an element in the diagram with the given ID.
      * @param id the ID to check
      * @return true if such an element exists, false otherwise

--- a/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
@@ -49,6 +49,7 @@ public class ElementIdManager {
         boolean foundId = false;
         while (!foundId) {
             id = getNewId();
+            if (Long.MAX_VALUE - id <= length * 0xFFL) continue; // Avoid overflows
             boolean noIdConflicts = true;
             for (int i = 1; i <= length; i++) {
                 if (existsWithId(getNextId(id, i))) {

--- a/src/main/resources/carleton/sysc4907/view/element/EditableLabel.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/EditableLabel.fxml
@@ -6,6 +6,6 @@
 <Group xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="carleton.sysc4907.controller.element.EditableLabelController">
-    <Label styleClass="diagram-text" fx:id="label" minHeight="10" minWidth="10"/>
+    <Label styleClass="diagram-text" fx:id="label" minHeight="10" minWidth="10" userData="0"/>
     <TextArea styleClass="diagram-text" fx:id="editableText"/>
 </Group>

--- a/src/test/java/carleton/sysc4907/command/AddCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandTest.java
@@ -71,7 +71,7 @@ public class AddCommandTest {
                     thenReturn(true);
             Mockito.when(mockElementsList.add(any(DiagramElement.class)))
                     .thenReturn(true);
-            Mockito.when(mockElementCreator.create(eq("testType"), anyLong()))
+            Mockito.when(mockElementCreator.create(eq("testType"), anyLong(), eq(true)))
                     .thenReturn(mockDiagramElement);
 
             AddCommandArgs args = new AddCommandArgs("testType", 2L);

--- a/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
@@ -1,13 +1,15 @@
 package carleton.sysc4907.processing;
 
 import carleton.sysc4907.DependencyInjector;
-import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.view.DiagramElement;
+import javafx.collections.FXCollections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -20,6 +22,9 @@ public class ElementCreatorTest {
     private DependencyInjector mockElementInjector;
 
     @Mock
+    private ElementIdManager mockElementIdManager;
+
+    @Mock
     private DiagramElement element1;
 
     @Mock
@@ -28,7 +33,11 @@ public class ElementCreatorTest {
     @Test
     public void resolveElementTemplates() throws Exception {
         // Test that the constructor does not throw an error for a valid XML file
-        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH);
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
+        Mockito.when(element1.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        Mockito.when(element2.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH, mockElementIdManager);
 
         assertEquals(
                 "/carleton/sysc4907/view/element/Rectangle.fxml",
@@ -42,13 +51,15 @@ public class ElementCreatorTest {
     @Test
     public void createElements() throws Exception {
         // Test that the constructor does not throw an error for a valid XML file
-        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH);
         Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
         Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
+        Mockito.when(element1.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        Mockito.when(element2.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH, mockElementIdManager);
 
-        assertEquals(element1, elementCreator.create("rectangle", 0L));
-        assertEquals(element2, elementCreator.create("uml-comment", 0L));
-        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/Rectangle.fxml");
-        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/UmlComment.fxml");
+        assertEquals(element1, elementCreator.create("rectangle", 0L, false));
+        assertEquals(element2, elementCreator.create("uml-comment", 0L, false));
+        Mockito.verify(mockElementInjector, Mockito.times(2)).load("/carleton/sysc4907/view/element/Rectangle.fxml");
+        Mockito.verify(mockElementInjector, Mockito.times(2)).load("/carleton/sysc4907/view/element/UmlComment.fxml");
     }
 }

--- a/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementCreatorTest.java
@@ -3,6 +3,7 @@ package carleton.sysc4907.processing;
 import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.collections.FXCollections;
+import javafx.scene.Node;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,9 +11,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.LinkedList;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ElementCreatorTest {
@@ -30,13 +31,12 @@ public class ElementCreatorTest {
     @Mock
     private DiagramElement element2;
 
+    @Mock
+    private DiagramElement element3;
+
     @Test
     public void resolveElementTemplates() throws Exception {
         // Test that the constructor does not throw an error for a valid XML file
-        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
-        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
-        Mockito.when(element1.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
-        Mockito.when(element2.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
         ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH, mockElementIdManager);
 
         assertEquals(
@@ -49,7 +49,31 @@ public class ElementCreatorTest {
     }
 
     @Test
-    public void createElements() throws Exception {
+    public void getSubElementCounts() throws Exception {
+        // Test that the constructor does not throw an error for a valid XML file
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
+
+        List<Node> nodes = new LinkedList<>();
+        nodes.add(element3);
+
+        Mockito.when(element1.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(nodes));
+        Mockito.when(element2.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        Mockito.when(element3.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        Mockito.when(element3.getUserData()).thenReturn("0");
+        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH, mockElementIdManager);
+
+        assertEquals(
+                1,
+                elementCreator.countIdSubElements("rectangle"));
+        assertEquals(
+                0,
+                elementCreator.countIdSubElements("uml-comment"));
+        assertThrows(IllegalArgumentException.class, () -> elementCreator.countIdSubElements("nonexistent"));
+    }
+
+    @Test
+    public void createElementsWithoutSubElements() throws Exception {
         // Test that the constructor does not throw an error for a valid XML file
         Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
         Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
@@ -57,9 +81,33 @@ public class ElementCreatorTest {
         Mockito.when(element2.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
         ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH, mockElementIdManager);
 
-        assertEquals(element1, elementCreator.create("rectangle", 0L, false));
-        assertEquals(element2, elementCreator.create("uml-comment", 0L, false));
-        Mockito.verify(mockElementInjector, Mockito.times(2)).load("/carleton/sysc4907/view/element/Rectangle.fxml");
-        Mockito.verify(mockElementInjector, Mockito.times(2)).load("/carleton/sysc4907/view/element/UmlComment.fxml");
+        assertEquals(element1, elementCreator.create("rectangle", 0L, true));
+        assertEquals(element2, elementCreator.create("uml-comment", 0L, true));
+        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/Rectangle.fxml");
+        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/UmlComment.fxml");
+    }
+
+    @Test
+    public void createElementsWithSubElements() throws Exception {
+        // Test that the constructor does not throw an error for a valid XML file
+        List<Node> nodes = new LinkedList<>();
+        nodes.add(element3);
+
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/Rectangle.fxml")).thenReturn(element1);
+        Mockito.when(mockElementInjector.load("/carleton/sysc4907/view/element/UmlComment.fxml")).thenReturn(element2);
+        Mockito.when(element1.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(nodes));
+        Mockito.when(element2.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        Mockito.when(element3.getChildrenUnmodifiable()).thenReturn(FXCollections.observableList(new LinkedList<>()));
+        Mockito.when(element3.getUserData()).thenReturn("0");
+        Mockito.when(mockElementIdManager.getNextId(0L, 1)).thenReturn(1L);
+        ElementCreator elementCreator = new ElementCreator(mockElementInjector, TEST_FILE_PATH, mockElementIdManager);
+
+        assertEquals(element1, elementCreator.create("rectangle", 0L, true));
+        assertEquals(element2, elementCreator.create("uml-comment", 0L, true));
+        Mockito.verify(element1).setUserData(0L);
+        Mockito.verify(element3).setUserData(1L);
+        Mockito.verify(element2).setUserData(0L);
+        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/Rectangle.fxml");
+        Mockito.verify(mockElementInjector).load("/carleton/sysc4907/view/element/UmlComment.fxml");
     }
 }

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerFunctionalTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerFunctionalTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import java.util.LinkedList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 
 public class ElementIdManagerFunctionalTest {
@@ -26,5 +27,22 @@ public class ElementIdManagerFunctionalTest {
         var id = elementIdManager.getNewId();
         var expectedLastBits = id & 0xFF;
         assertEquals(expectedLastBits, id & 0xFF);
+    }
+
+    @Test
+    public void testGetNewIdRange() {
+        SessionModel sessionModel = new SessionModel("12345678ABCD", new User(1, "TEST", PermissionLevel.HOST));
+        Pane editingArea = new Pane();
+        EditingAreaProvider.init(editingArea);
+        ElementIdManager elementIdManager = new ElementIdManager(sessionModel);
+        var id = elementIdManager.getNewIdRange(100);
+        System.out.println(id);
+        var expectedLastBits = id & 0xFF;
+        assertEquals(expectedLastBits, id & 0xFF);
+        for (int i = 1; i <= 100; i++) {
+            System.out.println(elementIdManager.getNextId(id, i));
+            System.out.println(String.format("0x%08X", elementIdManager.getNextId(id, i)));
+            assertFalse(elementIdManager.existsWithId(elementIdManager.getNextId(id, i)));
+        }
     }
 }

--- a/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
@@ -92,7 +93,7 @@ public class ElementLibraryPanelTest {
         Mockito.when(mockNodesList.add(any(Node.class))).thenReturn(true);
         Mockito.when(mockElementCreator.create("rectangleType", testId, true))
                 .thenReturn(mockDiagramElement);
-        Mockito.when(mockElementIdManager.getNewId()).thenReturn(testId);
+        Mockito.when(mockElementIdManager.getNewIdRange(anyInt())).thenReturn(testId);
 
         robot.clickOn("#elementsPane .button");
 

--- a/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/view/ElementLibraryPanelTest.java
@@ -90,7 +90,7 @@ public class ElementLibraryPanelTest {
         Mockito.when(mockElementsList.add(any(DiagramElement.class))).thenReturn(true);
         Mockito.when(editingArea.getChildren()).thenReturn(mockNodesList);
         Mockito.when(mockNodesList.add(any(Node.class))).thenReturn(true);
-        Mockito.when(mockElementCreator.create("rectangleType", testId))
+        Mockito.when(mockElementCreator.create("rectangleType", testId, true))
                 .thenReturn(mockDiagramElement);
         Mockito.when(mockElementIdManager.getNewId()).thenReturn(testId);
 


### PR DESCRIPTION
Resolves #42, required for #26.

Sub-elements can now be marked in FXML using userData="0". This will cause the sub-element to receive its own ID on element creation, so it can be targeted later, overwriting the "0" user data.
To generate these IDs, we check how many IDs an element plus all its sub-elements will need, from the FXML (in ElementCreator). We then find a number of consecutive free IDs via random attempts. The same IDs can be re-generated at the remote end from the first ID only.