### PR TITLE
Implement message interpreter

### DIFF
--- a/src/main/java/carleton/sysc4907/communications/Message.java
+++ b/src/main/java/carleton/sysc4907/communications/Message.java
@@ -1,0 +1,4 @@
+package carleton.sysc4907.communications;
+
+public record Message(MessageType type, Object payload) {
+}

--- a/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
+++ b/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
@@ -1,0 +1,49 @@
+package carleton.sysc4907.communications;
+
+import carleton.sysc4907.command.*;
+import carleton.sysc4907.command.args.AddCommandArgs;
+import carleton.sysc4907.command.args.MoveCommandArgs;
+import carleton.sysc4907.command.args.RemoveCommandArgs;
+import carleton.sysc4907.command.args.ResizeCommandArgs;
+import javafx.application.Platform;
+import javafx.scene.Parent;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MessageInterpreter {
+
+    private final Map<Class<?>, CommandFactory> commandFactories;
+
+    public MessageInterpreter(
+        AddCommandFactory addCommandFactory,
+        RemoveCommandFactory removeCommandFactory,
+        MoveCommandFactory moveCommandFactory,
+        ResizeCommandFactory resizeCommandFactory
+    ) {
+        this.commandFactories = new HashMap<>();
+        commandFactories.put(AddCommandArgs.class, addCommandFactory);
+        commandFactories.put(RemoveCommandArgs.class, removeCommandFactory);
+        commandFactories.put(MoveCommandArgs.class, moveCommandFactory);
+        commandFactories.put(ResizeCommandArgs.class, resizeCommandFactory);
+    }
+
+    public void interpret(Message message) {
+        switch (message.type()) {
+            case UPDATE -> interpretUpdate(message);
+        }
+    }
+
+    private void interpretUpdate(Message message) {
+        Object args = message.payload();
+        Class<?> argType = args.getClass();
+        var factory = commandFactories.get(argType);
+        if (factory == null) {
+            throw new IllegalArgumentException("The given message did not correspond to a known type of command arguments.");
+        }
+        Command<?> command = factory.create(argType.cast(args));
+
+        Platform.runLater(command::execute);
+    }
+}

--- a/src/main/java/carleton/sysc4907/communications/MessageType.java
+++ b/src/main/java/carleton/sysc4907/communications/MessageType.java
@@ -1,0 +1,8 @@
+package carleton.sysc4907.communications;
+
+public enum MessageType {
+    JOIN_REQUEST,
+    JOIN_RESPONSE,
+    UPDATE
+
+}

--- a/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
+++ b/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
@@ -1,0 +1,75 @@
+package carleton.sysc4907.communications;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.command.*;
+import carleton.sysc4907.command.args.MoveCommandArgs;
+import javafx.application.Platform;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class MessageInterpreterTest {
+
+    @Mock
+    private AddCommandFactory addCommandFactory;
+    @Mock
+    private RemoveCommandFactory removeCommandFactory;
+    @Mock
+    private MoveCommandFactory moveCommandFactory;
+    @Mock
+    private ResizeCommandFactory resizeCommandFactory;
+
+    @Mock
+    private Command<?> mockCommand;
+
+    @Test
+    public void interpretUpdateMoveCommand() {
+        // setup
+        MessageInterpreter interpreter = new MessageInterpreter(
+                addCommandFactory,
+                removeCommandFactory,
+                moveCommandFactory,
+                resizeCommandFactory
+        );
+        var args = new MoveCommandArgs(0, 0, 1, 1, 0L);
+        Mockito.when(moveCommandFactory.create(any(MoveCommandArgs.class))).thenReturn(mockCommand);
+        try (MockedStatic<Platform> platformMockedStatic = Mockito.mockStatic(Platform.class)) {
+            // runLater will do nothing by default
+            // test
+            interpreter.interpret(new Message(MessageType.UPDATE, args));
+
+            // verify
+            Mockito.verify(moveCommandFactory).create(any(MoveCommandArgs.class));
+            platformMockedStatic.verify(() -> Platform.runLater(any()));
+        }
+    }
+
+    @Test
+    public void interpretUpdateIncorrectPayload() {
+        // setup
+        MessageInterpreter interpreter = new MessageInterpreter(
+                addCommandFactory,
+                removeCommandFactory,
+                moveCommandFactory,
+                resizeCommandFactory
+        );
+        var payload = "Not an args object";
+        try (MockedStatic<Platform> platformMockedStatic = Mockito.mockStatic(Platform.class)) {
+            // runLater will do nothing by default
+            // test
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> interpreter.interpret(new Message(MessageType.UPDATE, payload)));
+
+            // verify
+            platformMockedStatic.verify(() -> Platform.runLater(any()), Mockito.never());
+        }
+    }
+}


### PR DESCRIPTION
Resolves #51.

Currently the interpreter can handle UPDATE messages, for which the payload should be some args object representing a command. It also catches the case where such messages have an invalid payload.