### PR TITLE
Connector prototype

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -13,6 +13,7 @@ import carleton.sysc4907.controller.SessionInfoBarController;
 import carleton.sysc4907.controller.SessionUsersMenuController;
 import carleton.sysc4907.controller.*;
 import carleton.sysc4907.controller.element.*;
+import carleton.sysc4907.controller.element.pathing.DirectPathStrategy;
 import carleton.sysc4907.model.*;
 import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.ElementIdManager;
@@ -125,7 +126,7 @@ public class DiagramEditorLoader {
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 () -> new EditableLabelController(editTextCommandFactory));
         elementControllerInjector.addInjectionMethod(ConnectorElementController.class,
-                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator));
+                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator, new DirectPathStrategy()));
 
         // Add instantiation methods to the main dependency injector, used to create UI elements
         injector.addInjectionMethod(SessionInfoBarController.class,

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -90,6 +90,7 @@ public class DiagramEditorLoader {
         MovePreviewCreator movePreviewCreator = new MovePreviewCreator(elementIdManager);
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
         ResizePreviewCreator resizePreviewCreator = new ResizePreviewCreator(elementIdManager);
+        ConnectorHandleCreator connectorHandleCreator = new ConnectorHandleCreator();
         DependencyInjector elementControllerInjector = new DependencyInjector();
         ElementCreator elementCreator;
         try {
@@ -124,7 +125,7 @@ public class DiagramEditorLoader {
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 () -> new EditableLabelController(editTextCommandFactory));
         elementControllerInjector.addInjectionMethod(ConnectorElementController.class,
-                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel));
+                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator));
 
         // Add instantiation methods to the main dependency injector, used to create UI elements
         injector.addInjectionMethod(SessionInfoBarController.class,

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -14,6 +14,7 @@ import carleton.sysc4907.controller.SessionUsersMenuController;
 import carleton.sysc4907.controller.*;
 import carleton.sysc4907.controller.element.*;
 import carleton.sysc4907.controller.element.pathing.DirectPathStrategy;
+import carleton.sysc4907.controller.element.pathing.OrthogonalPathStrategy;
 import carleton.sysc4907.model.*;
 import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.ElementIdManager;
@@ -126,7 +127,7 @@ public class DiagramEditorLoader {
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 () -> new EditableLabelController(editTextCommandFactory));
         elementControllerInjector.addInjectionMethod(ConnectorElementController.class,
-                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator, new DirectPathStrategy()));
+                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator, new OrthogonalPathStrategy()));
 
         // Add instantiation methods to the main dependency injector, used to create UI elements
         injector.addInjectionMethod(SessionInfoBarController.class,

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -123,6 +123,8 @@ public class DiagramEditorLoader {
                         resizeHandleCreator, resizePreviewCreator, resizeCommandFactory));
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 () -> new EditableLabelController(editTextCommandFactory));
+        elementControllerInjector.addInjectionMethod(ConnectorElementController.class,
+                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel));
 
         // Add instantiation methods to the main dependency injector, used to create UI elements
         injector.addInjectionMethod(SessionInfoBarController.class,

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -109,13 +109,15 @@ public class DiagramEditorLoader {
         AddCommandFactory addCommandFactory = new AddCommandFactory(diagramModel, elementCreator, manager);
         RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(diagramModel, elementIdManager, manager);
         EditTextCommandFactory editTextCommandFactory = new EditTextCommandFactory(elementIdManager, manager);
+        ConnectorMovePointCommandFactory connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(elementIdManager, manager);
         // Add factories to message interpreter: avoids circular dependencies
         interpreter.addFactories(
                 addCommandFactory,
                 removeCommandFactory,
                 moveCommandFactory,
                 resizeCommandFactory,
-                editTextCommandFactory
+                editTextCommandFactory,
+                connectorMovePointCommandFactory
         );
 
         // Add instantiation methods for the element injector, used to create diagram element controllers
@@ -128,7 +130,13 @@ public class DiagramEditorLoader {
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 () -> new EditableLabelController(editTextCommandFactory));
         elementControllerInjector.addInjectionMethod(ConnectorElementController.class,
-                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator, new CurvedPathStrategy()));
+                () -> new ConnectorElementController(
+                        movePreviewCreator,
+                        moveCommandFactory,
+                        diagramModel,
+                        connectorHandleCreator,
+                        connectorMovePointCommandFactory,
+                        new CurvedPathStrategy()));
 
         // Add instantiation methods to the main dependency injector, used to create UI elements
         injector.addInjectionMethod(SessionInfoBarController.class,
@@ -148,7 +156,7 @@ public class DiagramEditorLoader {
     /**
      * Opens the editor screen.
      * @param stage the stage to open on.
-     * @param injector the dependancy injector
+     * @param injector the dependency injector
      * @param manager the TCP manager
      * @throws IOException when loading the resources required for the scene fails
      */

--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -13,6 +13,7 @@ import carleton.sysc4907.controller.SessionInfoBarController;
 import carleton.sysc4907.controller.SessionUsersMenuController;
 import carleton.sysc4907.controller.*;
 import carleton.sysc4907.controller.element.*;
+import carleton.sysc4907.controller.element.pathing.CurvedPathStrategy;
 import carleton.sysc4907.controller.element.pathing.DirectPathStrategy;
 import carleton.sysc4907.controller.element.pathing.OrthogonalPathStrategy;
 import carleton.sysc4907.model.*;
@@ -127,7 +128,7 @@ public class DiagramEditorLoader {
         elementControllerInjector.addInjectionMethod(EditableLabelController.class,
                 () -> new EditableLabelController(editTextCommandFactory));
         elementControllerInjector.addInjectionMethod(ConnectorElementController.class,
-                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator, new OrthogonalPathStrategy()));
+                () -> new ConnectorElementController(movePreviewCreator, moveCommandFactory, diagramModel, connectorHandleCreator, new CurvedPathStrategy()));
 
         // Add instantiation methods to the main dependency injector, used to create UI elements
         injector.addInjectionMethod(SessionInfoBarController.class,

--- a/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommand.java
@@ -11,6 +11,9 @@ import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
 
+/**
+ * Command for moving the start or end point of a connector.
+ */
 public class ConnectorMovePointCommand implements Command<ConnectorMovePointCommandArgs> {
 
     private final ConnectorMovePointCommandArgs args;
@@ -22,12 +25,13 @@ public class ConnectorMovePointCommand implements Command<ConnectorMovePointComm
     }
 
     /**
-     * Executes the command
+     * Executes the command.
      */
     @Override
     public void execute() {
         var element = elementIdManager.getElementById(args.elementId());
         if (element == null) return;
+        // Find connector controller from properties: this must be specified in FXML, see Controller.fxml
         ConnectorElementController controller = (ConnectorElementController) element.getProperties().get("controller");
         if (controller == null) throw new IllegalArgumentException();
         if (args.isStart()) {
@@ -41,6 +45,6 @@ public class ConnectorMovePointCommand implements Command<ConnectorMovePointComm
 
     @Override
     public ConnectorMovePointCommandArgs getArgs() {
-        return null;
+        return args;
     }
 }

--- a/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommand.java
@@ -1,0 +1,46 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.command.Command;
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.controller.element.ConnectorElementController;
+import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.processing.ElementIdManager;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+
+public class ConnectorMovePointCommand implements Command<ConnectorMovePointCommandArgs> {
+
+    private final ConnectorMovePointCommandArgs args;
+    private final ElementIdManager elementIdManager;
+
+    public ConnectorMovePointCommand(ConnectorMovePointCommandArgs args, ElementIdManager elementIdManager) {
+        this.args = args;
+        this.elementIdManager = elementIdManager;
+    }
+
+    /**
+     * Executes the command
+     */
+    @Override
+    public void execute() {
+        var element = elementIdManager.getElementById(args.elementId());
+        if (element == null) return;
+        ConnectorElementController controller = (ConnectorElementController) element.getProperties().get("controller");
+        if (controller == null) throw new IllegalArgumentException();
+        if (args.isStart()) {
+            controller.setStartX(controller.getStartX() + args.deltaX());
+            controller.setStartY(controller.getStartY() + args.deltaY());
+        } else {
+            controller.setEndX(controller.getEndX() + args.deltaX());
+            controller.setEndY(controller.getEndY() + args.deltaY());
+        }
+    }
+
+    @Override
+    public ConnectorMovePointCommandArgs getArgs() {
+        return null;
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommandFactory.java
@@ -1,0 +1,26 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.processing.ElementIdManager;
+
+public class ConnectorMovePointCommandFactory extends TrackedCommandFactory<Command<ConnectorMovePointCommandArgs>, ConnectorMovePointCommandArgs> {
+
+    private final ElementIdManager elementIdManager;
+
+    public ConnectorMovePointCommandFactory(ElementIdManager elementIdManager, Manager manager) {
+        super(manager);
+        this.elementIdManager = elementIdManager;
+    }
+
+    /**
+     * Creates a command object
+     *
+     * @param args the arguments for the command
+     * @return a command of the specified type
+     */
+    @Override
+    public Command<ConnectorMovePointCommandArgs> create(ConnectorMovePointCommandArgs args) {
+        return new ConnectorMovePointCommand(args, elementIdManager);
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/args/ConnectorMovePointCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ConnectorMovePointCommandArgs.java
@@ -1,0 +1,6 @@
+package carleton.sysc4907.command.args;
+
+import java.io.Serializable;
+
+public record ConnectorMovePointCommandArgs(boolean isStart, double deltaX, double deltaY, long elementId) implements Serializable {
+}

--- a/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
+++ b/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
@@ -20,7 +20,8 @@ public class MessageInterpreter {
         RemoveCommandFactory removeCommandFactory,
         MoveCommandFactory moveCommandFactory,
         ResizeCommandFactory resizeCommandFactory,
-        EditTextCommandFactory editTextCommandFactory
+        EditTextCommandFactory editTextCommandFactory,
+        ConnectorMovePointCommandFactory connectorMovePointCommandFactory
     ) {
         this();
         addFactories(
@@ -28,7 +29,8 @@ public class MessageInterpreter {
                 removeCommandFactory,
                 moveCommandFactory,
                 resizeCommandFactory,
-                editTextCommandFactory);
+                editTextCommandFactory,
+                connectorMovePointCommandFactory);
     }
 
     public void addFactories(
@@ -36,13 +38,14 @@ public class MessageInterpreter {
             RemoveCommandFactory removeCommandFactory,
             MoveCommandFactory moveCommandFactory,
             ResizeCommandFactory resizeCommandFactory,
-            EditTextCommandFactory editTextCommandFactory
-    ) {
+            EditTextCommandFactory editTextCommandFactory,
+            ConnectorMovePointCommandFactory connectorMovePointCommandFactory) {
         commandFactories.put(AddCommandArgs.class, addCommandFactory);
         commandFactories.put(RemoveCommandArgs.class, removeCommandFactory);
         commandFactories.put(MoveCommandArgs.class, moveCommandFactory);
         commandFactories.put(ResizeCommandArgs.class, resizeCommandFactory);
         commandFactories.put(EditTextCommandArgs.class, editTextCommandFactory);
+        commandFactories.put(ConnectorMovePointCommandArgs.class, connectorMovePointCommandFactory);
     }
 
     public void interpret(Message message) {

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -184,7 +184,7 @@ public class ConnectorElementController extends DiagramElementController {
      * Paths that are close to horizontal or vertical will be set to be in that direction.
      * Endpoints that are marked as "snapped" will not have their directions changed.
      */
-    private void updateDirections() {
+    public void updateDirections() {
         var deltaX = Math.abs(getEndX() - getStartX()) + 0.01; // add 0.01 to avoid division by 0 errors
         var deltaY = Math.abs(getEndY() - getStartY()) + 0.01;
 
@@ -300,6 +300,22 @@ public class ConnectorElementController extends DiagramElementController {
 
     public void setEndY(double y) {
         endY.set(y);
+    }
+
+    public boolean getIsStartHorizontal() {
+        return isStartHorizontal.get();
+    }
+
+    public void setIsStartHorizontal(boolean isHorizontal) {
+        isStartHorizontal.set(isHorizontal);
+    }
+
+    public boolean getIsEndHorizontal() {
+        return isEndHorizontal.get();
+    }
+
+    public void setIsEndHorizontal(boolean isHorizontal) {
+        isEndHorizontal.set(isHorizontal);
     }
 
     public void setSnapStart(boolean isSnap) {

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -2,10 +2,46 @@ package carleton.sysc4907.controller.element;
 
 import carleton.sysc4907.command.MoveCommandFactory;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.fxml.FXML;
+import javafx.scene.Node;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
+
+import java.util.LinkedList;
+import java.util.List;
 
 public class ConnectorElementController extends DiagramElementController {
+
+    private final ConnectorHandleCreator connectorHandleCreator;
+    private final List<Node> handles;
+
+    // All coordinates relative to the parent element (editing area)!
+    private final DoubleProperty startX = new SimpleDoubleProperty();
+    private final DoubleProperty startY = new SimpleDoubleProperty();
+    private final DoubleProperty endX = new SimpleDoubleProperty();
+    private final DoubleProperty endY = new SimpleDoubleProperty();
+
+    @FXML
+    private Path connectorPath;
+
+    private PathType pathType;
+
+    private boolean movePointDragging = false;
+    private double dragStartX;
+    private double dragStartY;
+
+    private double moveDragStartX;
+    private double moveDragStartY;
+
     /**
-     * Constructs a new DiagramElementController.
+     * Constructs a new ConnectorElementController.
      *
      * @param previewCreator     a MovePreviewCreator, used to create the move preview
      * @param moveCommandFactory a MoveCommandFactory, used to create move commands
@@ -14,12 +50,125 @@ public class ConnectorElementController extends DiagramElementController {
     public ConnectorElementController(
             MovePreviewCreator previewCreator,
             MoveCommandFactory moveCommandFactory,
-            DiagramModel diagramModel) {
+            DiagramModel diagramModel,
+            ConnectorHandleCreator connectorHandleCreator) {
         super(previewCreator, moveCommandFactory, diagramModel);
+        this.connectorHandleCreator = connectorHandleCreator;
+        this.handles = new LinkedList<>();
+        diagramModel.getSelectedElements().addListener((ListChangeListener<DiagramElement>) change -> {
+            while (change.next()) {
+                if (change.wasAdded() && change.getAddedSubList().contains(element)) {
+                    toggleShowPointDragHandles(true);
+                } else if (change.wasRemoved() && change.getRemoved().contains(element)) {
+                    toggleShowPointDragHandles(false);
+                }
+            }
+        });
     }
 
     @Override
     public void initialize() {
         super.initialize();
+        ChangeListener<Number> listener = (observableValue, number, t1) -> {
+            reposition();
+            recalculatePath();
+        };
+        startX.addListener(listener);
+        startY.addListener(listener);
+        endX.addListener(listener);
+        endY.addListener(listener);
+        setEndX(100);
+        setEndY(20);
+    }
+
+    private void toggleShowPointDragHandles(boolean showHandles) {
+        if (showHandles) {
+            var handle = connectorHandleCreator.createMovePointHandle(element, startX, startY);
+            handle.setOnDragDetected(this::handleDragDetectedStartMovePoint);
+            handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, startX, startY));
+            handles.add(handle);
+            handle = connectorHandleCreator.createMovePointHandle(element, endX, endY);
+            handle.setOnDragDetected(this::handleDragDetectedStartMovePoint);
+            handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, endX, endY));
+            handles.add(handle);
+        } else {
+            for (Node handle : handles) {
+                connectorHandleCreator.deleteMovePointHandle(element, handle);
+            }
+            handles.clear();
+        }
+    }
+
+    private void reposition() {
+        double leftmostX = Math.min(getStartX(), getEndX());
+        double topmostY = Math.min(getStartY(), getEndY());
+        element.setLayoutX(leftmostX);
+        element.setLayoutY(topmostY);
+    }
+
+    private void recalculatePath() {
+        // Put this in a Strategy?
+        connectorPath.getElements().clear();
+        connectorPath.getElements().add(new MoveTo(adjustX(getStartX()), adjustY(getStartY())));
+        connectorPath.getElements().add(new LineTo(adjustX(getEndX()), adjustY(getEndY())));
+    }
+
+    private void handleDragDetectedStartMovePoint(MouseEvent event) {
+        movePointDragging = true;
+        dragStartX = event.getSceneX();
+        dragStartY = event.getSceneY();
+        event.consume();
+    }
+
+    private void handleMouseReleasedResize(MouseEvent event, DoubleProperty x, DoubleProperty y) {
+        if (!movePointDragging) {
+            return;
+        }
+        movePointDragging = false;
+        System.out.println(x.get());
+        System.out.println(x.get() + event.getSceneX() - dragStartX);
+        x.set(x.get() + event.getSceneX() - dragStartX);
+        y.set(y.get() + event.getSceneY() - dragStartY);
+        event.consume();
+    }
+
+    public double getStartX() {
+        return startX.get();
+    }
+
+    public void setStartX(double x) {
+        startX.set(x);
+    }
+
+    public double getStartY() {
+        return startY.get();
+    }
+
+    public void setStartY(double y) {
+        startY.set(y);
+    }
+
+    public double getEndX() {
+        return endX.get();
+    }
+
+    public void setEndX(double x) {
+        endX.set(x);
+    }
+
+    public double getEndY() {
+        return endY.get();
+    }
+
+    public void setEndY(double y) {
+        endY.set(y);
+    }
+
+    private double adjustX(double x) {
+        return x - element.getLayoutX();
+    }
+
+    private double adjustY(double y) {
+        return y - element.getLayoutY();
     }
 }

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -15,6 +15,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
+import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
@@ -123,6 +124,18 @@ public class ConnectorElementController extends DiagramElementController {
         setEndY(20);
     }
 
+    @Override
+    protected ImageView takeMovePreviewImage() {
+        toggleShowPointDragHandles(false);
+        var preview = super.takeMovePreviewImage();
+        toggleShowPointDragHandles(true);
+        return preview;
+    }
+
+    /**
+     * Shows or hides handles which allow the endpoints of the connector to be moved.
+     * @param showHandles true if the handles for moving points should be shown, false if they should be hidden
+     */
     private void toggleShowPointDragHandles(boolean showHandles) {
         if (showHandles) {
             var handle = connectorHandleCreator.createMovePointHandle(element, startX, startY);
@@ -141,6 +154,10 @@ public class ConnectorElementController extends DiagramElementController {
         }
     }
 
+    /**
+     * Repositions the element so that neither of the endpoints have negative coordinates.
+     * This will move the endpoints to compensate, so that they are at the same position on the diagram.
+     */
     private void reposition() {
         repositioning = true;
         double leftmostX = Math.min(getStartX(), getEndX());
@@ -150,6 +167,9 @@ public class ConnectorElementController extends DiagramElementController {
         repositioning = false;
     }
 
+    /**
+     * Uses this connector's pathing strategy to re-make the connector's path. Overwrites the previous path.
+     */
     private void recalculatePath() {
         pathingStrategy.makePath(
                 connectorPath,
@@ -158,6 +178,12 @@ public class ConnectorElementController extends DiagramElementController {
         );
     }
 
+    /**
+     * Updates this connector's start and end directions, i.e. whether the path should start and end
+     * horizontally or vertically.
+     * Paths that are close to horizontal or vertical will be set to be in that direction.
+     * Endpoints that are marked as "snapped" will not have their directions changed.
+     */
     private void updateDirections() {
         var deltaX = Math.abs(getEndX() - getStartX()) + 0.01; // add 0.01 to avoid division by 0 errors
         var deltaY = Math.abs(getEndY() - getStartY()) + 0.01;
@@ -204,6 +230,10 @@ public class ConnectorElementController extends DiagramElementController {
         }
     }
 
+    /**
+     * Handler for the endpoint move handles, starts a drag operation.
+     * @param event the mouse event
+     */
     private void handleDragDetectedStartMovePoint(MouseEvent event) {
         movePointDragging = true;
         dragStartX = event.getSceneX();
@@ -211,6 +241,11 @@ public class ConnectorElementController extends DiagramElementController {
         event.consume();
     }
 
+    /**
+     * Handler for the endpoint move handlers. Moves the dragged endpoint to where the mouse was released.
+     * @param event the mouse release event
+     * @param isStart true if the start point was the one dragged, false if it was the end point
+     */
     private void handleMouseReleasedResize(MouseEvent event, boolean isStart) {
         if (!movePointDragging) {
             return;
@@ -226,8 +261,13 @@ public class ConnectorElementController extends DiagramElementController {
         event.consume();
     }
 
+    /**
+     * Sets the pathing strategy of this connector.
+     * @param strategy the new PathingStrategy to use when calculating paths
+     */
     public void setPathingStrategy(PathingStrategy strategy) {
         this.pathingStrategy = strategy;
+        recalculatePath();
     }
 
     public double getStartX() {

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -63,6 +63,8 @@ public class ConnectorElementController extends DiagramElementController {
         this.connectorHandleCreator = connectorHandleCreator;
         this.pathingStrategy = pathingStrategy;
         this.handles = new LinkedList<>();
+        isStartHorizontal.set(true);
+        isEndHorizontal.set(false);
         diagramModel.getSelectedElements().addListener((ListChangeListener<DiagramElement>) change -> {
             while (change.next()) {
                 if (change.wasAdded() && change.getAddedSubList().contains(element)) {
@@ -81,10 +83,15 @@ public class ConnectorElementController extends DiagramElementController {
             reposition();
             recalculatePath();
         };
+        ChangeListener<Boolean> booleanListener = (observableValue, bool, t1) -> {
+            recalculatePath();
+        };
         startX.addListener(listener);
         startY.addListener(listener);
         endX.addListener(listener);
         endY.addListener(listener);
+        isStartHorizontal.addListener(booleanListener);
+        isEndHorizontal.addListener(booleanListener);
         element.layoutXProperty().addListener((observableValue, number, t1) -> {
             if (repositioning) {
                 return;

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -262,6 +262,14 @@ public class ConnectorElementController extends DiagramElementController {
         endY.set(y);
     }
 
+    public void setSnapStart(boolean isSnap) {
+        isStartSnapping = isSnap;
+    }
+
+    public void setSnapEnd(boolean isSnap) {
+        isEndSnapping = isSnap;
+    }
+
     private double adjustX(double x) {
         return x - element.getLayoutX();
     }

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -1,0 +1,25 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.command.MoveCommandFactory;
+import carleton.sysc4907.model.DiagramModel;
+
+public class ConnectorElementController extends DiagramElementController {
+    /**
+     * Constructs a new DiagramElementController.
+     *
+     * @param previewCreator     a MovePreviewCreator, used to create the move preview
+     * @param moveCommandFactory a MoveCommandFactory, used to create move commands
+     * @param diagramModel       the DiagramModel for the current diagram
+     */
+    public ConnectorElementController(
+            MovePreviewCreator previewCreator,
+            MoveCommandFactory moveCommandFactory,
+            DiagramModel diagramModel) {
+        super(previewCreator, moveCommandFactory, diagramModel);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -159,8 +159,8 @@ public class ConnectorElementController extends DiagramElementController {
     }
 
     private void updateDirections() {
-        var deltaX = Math.abs(getEndX() - getStartX());
-        var deltaY = Math.abs(getEndY() - getStartY());
+        var deltaX = Math.abs(getEndX() - getStartX()) + 0.01; // add 0.01 to avoid division by 0 errors
+        var deltaY = Math.abs(getEndY() - getStartY()) + 0.01;
 
         if (isStartSnapping && isEndSnapping) {
             return; // can't update anything

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -6,6 +6,7 @@ import carleton.sysc4907.view.DiagramElement;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -37,8 +38,7 @@ public class ConnectorElementController extends DiagramElementController {
     private double dragStartX;
     private double dragStartY;
 
-    private double moveDragStartX;
-    private double moveDragStartY;
+    private boolean repositioning = false;
 
     /**
      * Constructs a new ConnectorElementController.
@@ -77,6 +77,22 @@ public class ConnectorElementController extends DiagramElementController {
         startY.addListener(listener);
         endX.addListener(listener);
         endY.addListener(listener);
+        element.layoutXProperty().addListener((observableValue, number, t1) -> {
+            if (repositioning) {
+                return;
+            }
+            double deltaX = t1.doubleValue() - number.doubleValue();
+            setStartX(deltaX + getStartX());
+            setEndX(deltaX + getEndX());
+        });
+        element.layoutYProperty().addListener((observableValue, number, t1) -> {
+            if (repositioning) {
+                return;
+            }
+            double deltaY = t1.doubleValue() - number.doubleValue();
+            setStartY(deltaY + getStartY());
+            setEndY(deltaY + getEndY());
+        });
         setEndX(100);
         setEndY(20);
     }
@@ -100,10 +116,12 @@ public class ConnectorElementController extends DiagramElementController {
     }
 
     private void reposition() {
+        repositioning = true;
         double leftmostX = Math.min(getStartX(), getEndX());
         double topmostY = Math.min(getStartY(), getEndY());
         element.setLayoutX(leftmostX);
         element.setLayoutY(topmostY);
+        repositioning = false;
     }
 
     private void recalculatePath() {

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorHandleCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorHandleCreator.java
@@ -1,0 +1,40 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.view.DiagramElement;
+import javafx.beans.property.DoubleProperty;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.shape.Rectangle;
+
+import java.io.IOException;
+
+public class ConnectorHandleCreator {
+
+    private final double HANDLE_SIZE = 10;
+
+    public ConnectorHandleCreator() {
+
+    }
+
+    public Node createMovePointHandle(DiagramElement element, DoubleProperty x, DoubleProperty y) {
+        FXMLLoader loader = new FXMLLoader();
+        loader.setLocation(ConnectorHandleCreator.class.getResource("/carleton/sysc4907/view/element/ResizeHandle.fxml"));
+        Rectangle resizeHandle = null;
+        try {
+            resizeHandle = loader.load();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        element.getChildren().add(resizeHandle);
+        resizeHandle.layoutXProperty().bind(x.subtract(HANDLE_SIZE / 2).subtract(element.layoutXProperty()));
+        resizeHandle.layoutYProperty().bind(y.subtract(HANDLE_SIZE / 2).subtract(element.layoutYProperty()));
+        return resizeHandle;
+    }
+
+    public void deleteMovePointHandle(DiagramElement element, Node handle) {
+        if (handle == null) {
+            return;
+        }
+        element.getChildren().remove(handle);
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -85,6 +85,18 @@ public abstract class DiagramElementController {
         });
     }
 
+    /**
+     * Creates a move preview by taking a screenshot of the element. Also handles any preparation before and after it,
+     * to ensure that the preview is the same size as the actual element.
+     * @return the preview element as an ImageView
+     */
+    protected ImageView takeMovePreviewImage() {
+        element.getStyleClass().removeAll(SELECTED_STYLE_CLASS);
+        var preview = previewCreator.createMovePreview(element, dragStartX, dragStartY);
+        element.getStyleClass().add(SELECTED_STYLE_CLASS);
+        return preview;
+    }
+
     protected void addMouseHandler(EventType<MouseEvent> type, EventHandler<MouseEvent> handler) {
         List<EventHandler<MouseEvent>> existingHandlers = mouseHandlers.computeIfAbsent(type, k -> new LinkedList<>());
         existingHandlers.add(handler);
@@ -126,9 +138,7 @@ public abstract class DiagramElementController {
         dragStartX = event.getSceneX();
         dragStartY = event.getSceneY();
         previewCreator.deleteMovePreview(element, preview);
-        element.getStyleClass().removeAll(SELECTED_STYLE_CLASS);
-        preview = previewCreator.createMovePreview(element, dragStartX, dragStartY);
-        element.getStyleClass().add(SELECTED_STYLE_CLASS);
+        preview = takeMovePreviewImage();
     }
 
     protected void handleMouseDraggedMovePreview(MouseEvent event) {

--- a/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
@@ -3,9 +3,11 @@ package carleton.sysc4907.controller.element;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
+import javafx.scene.SnapshotParameters;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
 import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
 
 /**
  * Class responsible for creating and deleting previews when a diagram element is dragged in the diagram.
@@ -30,7 +32,9 @@ public class MovePreviewCreator {
      */
     public ImageView createMovePreview(DiagramElement element, double dragStartX, double dragStartY) {
         // create preview
-        WritableImage img = element.snapshot(null, new WritableImage(
+        SnapshotParameters parameters = new SnapshotParameters();
+        parameters.setFill(Color.TRANSPARENT);
+        WritableImage img = element.snapshot(parameters, new WritableImage(
                 (int) element.getBoundsInParent().getWidth() + 2,
                 (int) element.getBoundsInParent().getHeight() + 2));
 

--- a/src/main/java/carleton/sysc4907/controller/element/PathType.java
+++ b/src/main/java/carleton/sysc4907/controller/element/PathType.java
@@ -1,0 +1,7 @@
+package carleton.sysc4907.controller.element;
+
+public enum PathType {
+    STRAIGHT,
+    ORTHOGONAL,
+    CURVED
+}

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -10,6 +10,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.event.Event;
 import javafx.scene.Node;
+import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 
@@ -80,6 +81,14 @@ public abstract class ResizableElementController extends DiagramElementControlle
             toggleShowResizeHandles(!showHandles);
             toggleShowResizeHandles(showHandles);
         });
+    }
+
+    @Override
+    protected ImageView takeMovePreviewImage() {
+        toggleShowResizeHandles(false);
+        var preview = super.takeMovePreviewImage();
+        toggleShowResizeHandles(true);
+        return preview;
     }
 
     private void createResizeHandles() {

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategy.java
@@ -2,6 +2,10 @@ package carleton.sysc4907.controller.element.pathing;
 
 import javafx.scene.shape.*;
 
+/**
+ * Pathing strategy used for creating curved paths.
+ * Uses a quadratic curve for diagonal paths or a cubic curve for straighter paths.
+ */
 public class CurvedPathStrategy implements PathingStrategy {
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategy.java
@@ -1,0 +1,57 @@
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.*;
+
+public class CurvedPathStrategy implements PathingStrategy {
+
+    /**
+     * Clears the given path, replacing it with a path from the start point to the end point.
+     *
+     * @param path              the Path object to set up
+     * @param startX            the X (horizontal) coordinate of the start point
+     * @param startY            the Y (vertical) coordinate of the start point
+     * @param isStartHorizontal true if the line should start horizontally at the start point, otherwise vertical. Used for snapping.
+     * @param endX              the X (horizontal) coordinate of the end point
+     * @param endY              the Y (vertical) coordinate of the end point
+     * @param isEndHorizontal   true if the line should start horizontally at the end point, otherwise vertical. Used for snapping.
+     */
+    @Override
+    public void makePath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal) {
+        path.getElements().clear();
+        if (isStartHorizontal != isEndHorizontal) {
+            makeBentPath(path, startX, startY, isStartHorizontal, endX, endY, isEndHorizontal);
+        } else {
+            makeElbowPath(path, startX, startY, isStartHorizontal, endX, endY, isEndHorizontal);
+        }
+    }
+
+    protected void makeBentPath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal
+    ) {
+        double cornerX = isStartHorizontal ? endX : startX;
+        double cornerY = isEndHorizontal ? endY : startY;
+        path.getElements().add(new MoveTo(startX, startY));
+
+        path.getElements().add(new QuadCurveTo(cornerX, cornerY, endX, endY));
+    }
+
+    protected void makeElbowPath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal
+    ) {
+        path.getElements().add(new MoveTo(startX, startY));
+        if (isStartHorizontal) {
+            double ctrlX = (startX + endX) / 2;
+            path.getElements().add(new CubicCurveTo(ctrlX, startY, ctrlX, endY, endX, endY));
+        } else {
+            double ctrlY = (startY + endY) / 2;
+            path.getElements().add(new CubicCurveTo(startX, ctrlY, endX, ctrlY, endX, endY));
+        }
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategy.java
@@ -1,0 +1,29 @@
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
+
+public class DirectPathStrategy implements PathingStrategy {
+
+    /**
+     * Clears the given path, replacing it with a path from the start point to the end point.
+     *
+     * @param path              the Path object to set up
+     * @param startX            the X (horizontal) coordinate of the start point
+     * @param startY            the Y (vertical) coordinate of the start point
+     * @param isStartHorizontal true if the line should start horizontally at the start point, otherwise vertical. Used for snapping.
+     * @param endX              the X (horizontal) coordinate of the end point
+     * @param endY              the Y (vertical) coordinate of the end point
+     * @param isEndHorizontal   true if the line should start horizontally at the end point, otherwise vertical. Used for snapping.
+     */
+    @Override
+    public void makePath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal) {
+        path.getElements().clear();
+        path.getElements().add(new MoveTo(startX, startY));
+        path.getElements().add(new LineTo(endX, endY));
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategy.java
@@ -4,6 +4,9 @@ import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 
+/**
+ * Pathing strategy for creating straight paths between two points.
+ */
 public class DirectPathStrategy implements PathingStrategy {
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategy.java
@@ -1,0 +1,60 @@
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.*;
+
+public class OrthogonalPathStrategy implements PathingStrategy {
+    /**
+     * Clears the given path, replacing it with a path from the start point to the end point.
+     *
+     * @param path              the Path object to set up
+     * @param startX            the X (horizontal) coordinate of the start point
+     * @param startY            the Y (vertical) coordinate of the start point
+     * @param isStartHorizontal true if the line should start horizontally at the start point, otherwise vertical. Used for snapping.
+     * @param endX              the X (horizontal) coordinate of the end point
+     * @param endY              the Y (vertical) coordinate of the end point
+     * @param isEndHorizontal   true if the line should start horizontally at the end point, otherwise vertical. Used for snapping.
+     */
+    @Override
+    public void makePath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal
+    ) {
+        path.getElements().clear();
+        if (isStartHorizontal != isEndHorizontal) {
+            makeBentPath(path, startX, startY, isStartHorizontal, endX, endY, isEndHorizontal);
+        } else {
+            makeElbowPath(path, startX, startY, isStartHorizontal, endX, endY, isEndHorizontal);
+        }
+    }
+
+    protected void makeBentPath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal
+    ) {
+        double cornerX = isStartHorizontal ? endX : startX;
+        double cornerY = isEndHorizontal ? endY : startY;
+        path.getElements().add(new MoveTo(startX, startY));
+        path.getElements().add(new LineTo(cornerX, cornerY));
+        path.getElements().add(new LineTo(endX, endY));
+    }
+
+    protected void makeElbowPath(
+            Path path,
+            double startX, double startY, boolean isStartHorizontal,
+            double endX, double endY, boolean isEndHorizontal
+    ) {
+        double midpoint = isStartHorizontal ? (startX + endX) / 2 : (startY + endY) / 2;
+        double midpoint2 = isStartHorizontal ? endY : endX;
+        path.getElements().add(new MoveTo(startX, startY));
+        if (isStartHorizontal) {
+            path.getElements().add(new HLineTo(midpoint));
+            path.getElements().add(new VLineTo(midpoint2));
+        } else {
+            path.getElements().add(new VLineTo(midpoint));
+            path.getElements().add(new HLineTo(midpoint2));
+        }
+        path.getElements().add(new LineTo(endX, endY));
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategy.java
@@ -2,6 +2,9 @@ package carleton.sysc4907.controller.element.pathing;
 
 import javafx.scene.shape.*;
 
+/**
+ * Pathing strategy for creating orthogonal paths between two points: either an elbow-shaped path or a path via one corner.
+ */
 public class OrthogonalPathStrategy implements PathingStrategy {
     /**
      * Clears the given path, replacing it with a path from the start point to the end point.

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/PathingStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/PathingStrategy.java
@@ -2,6 +2,9 @@ package carleton.sysc4907.controller.element.pathing;
 
 import javafx.scene.shape.Path;
 
+/**
+ * Interface representing a Strategy used for creating connector paths given two points.
+ */
 public interface PathingStrategy {
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/element/pathing/PathingStrategy.java
+++ b/src/main/java/carleton/sysc4907/controller/element/pathing/PathingStrategy.java
@@ -1,0 +1,22 @@
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.Path;
+
+public interface PathingStrategy {
+
+    /**
+     * Clears the given path, replacing it with a path from the start point to the end point.
+     * @param path the Path object to set up
+     * @param startX the X (horizontal) coordinate of the start point
+     * @param startY the Y (vertical) coordinate of the start point
+     * @param isStartHorizontal true if the line should start horizontally at the start point, otherwise vertical. Used for snapping.
+     * @param endX the X (horizontal) coordinate of the end point
+     * @param endY the Y (vertical) coordinate of the end point
+     * @param isEndHorizontal true if the line should start horizontally at the end point, otherwise vertical. Used for snapping.
+     */
+    void makePath(
+        Path path,
+        double startX, double startY, boolean isStartHorizontal,
+        double endX, double endY, boolean isEndHorizontal
+    );
+}

--- a/src/main/resources/carleton/sysc4907/templates.xml
+++ b/src/main/resources/carleton/sysc4907/templates.xml
@@ -4,4 +4,5 @@
     <!-- Element type names should be human-readable: they are displayed on the UI! -->
     <template type="Rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>
     <template type="UML Comment" fxml="/carleton/sysc4907/view/element/UmlComment.fxml"/>
+    <template type="Line" fxml="/carleton/sysc4907/view/element/Connector.fxml"/>
 </templates>

--- a/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.shape.Path?>
 <DiagramElement xmlns="http://javafx.com/javafx" fx:id="element"
                 xmlns:fx="http://javafx.com/fxml"
-                fx:controller="carleton.sysc4907.controller.element.ConnectorElementController" styleClass="debug">
+                fx:controller="carleton.sysc4907.controller.element.ConnectorElementController">
     <Path fx:id="connectorPath">
     </Path>
 </DiagramElement>

--- a/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
@@ -11,6 +11,10 @@
 <DiagramElement xmlns="http://javafx.com/javafx" fx:id="element"
                 xmlns:fx="http://javafx.com/fxml"
                 fx:controller="carleton.sysc4907.controller.element.ConnectorElementController">
+    <properties>
+        <!-- Set controller as property so commands can find it-->
+        <controller><fx:reference source="controller"/></controller>
+    </properties>
     <Path fx:id="connectorPath">
     </Path>
 </DiagramElement>

--- a/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import carleton.sysc4907.view.DiagramElement?>
+<?import javafx.scene.shape.Path?>
+<?import javafx.scene.shape.MoveTo?>
+<?import javafx.scene.shape.LineTo?>
+<DiagramElement xmlns="http://javafx.com/javafx" fx:id="element"
+                xmlns:fx="http://javafx.com/fxml"
+                fx:controller="carleton.sysc4907.controller.element.ConnectorElementController">
+    <Path>
+        <elements>
+            <MoveTo/>
+            <LineTo x="100" y="50"/>
+        </elements>
+    </Path>
+</DiagramElement>

--- a/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
@@ -8,15 +8,9 @@
 
 <?import carleton.sysc4907.view.DiagramElement?>
 <?import javafx.scene.shape.Path?>
-<?import javafx.scene.shape.MoveTo?>
-<?import javafx.scene.shape.LineTo?>
 <DiagramElement xmlns="http://javafx.com/javafx" fx:id="element"
                 xmlns:fx="http://javafx.com/fxml"
-                fx:controller="carleton.sysc4907.controller.element.ConnectorElementController">
-    <Path>
-        <elements>
-            <MoveTo/>
-            <LineTo x="100" y="50"/>
-        </elements>
+                fx:controller="carleton.sysc4907.controller.element.ConnectorElementController" styleClass="debug">
+    <Path fx:id="connectorPath">
     </Path>
 </DiagramElement>

--- a/src/main/resources/stylesheet/DiagramElementsStyle.css
+++ b/src/main/resources/stylesheet/DiagramElementsStyle.css
@@ -66,3 +66,12 @@
     -fx-border-color: #38B6FF;
     -fx-border-style: dashed;
 }
+
+.debug {
+    -fx-fill: #00000000;
+    -fx-stroke: red;
+    -fx-stroke-dash-array: 5;
+    -fx-stroke-width: 10;
+    -fx-border-color: red;
+    -fx-border-style: dashed;
+}

--- a/src/test/java/carleton/sysc4907/command/ConnectorMovePointCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/ConnectorMovePointCommandTest.java
@@ -1,0 +1,73 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.command.args.MoveCommandArgs;
+import carleton.sysc4907.controller.element.ConnectorElementController;
+import carleton.sysc4907.processing.ElementIdManager;
+import javafx.collections.ObservableMap;
+import javafx.scene.Node;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectorMovePointCommandTest {
+    @Mock
+    private Node mockNode;
+    @Mock
+    private ConnectorElementController mockConnectorController;
+    @Mock
+    private ElementIdManager mockElementIdManager;
+    @Mock
+    private ObservableMap<Object, Object> mockPropertiesMap;
+
+    @Test
+    void executeMoveStartPoint() {
+        long testId = 12L;
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+        when(mockNode.getProperties()).thenReturn(mockPropertiesMap);
+        when(mockPropertiesMap.get("controller")).thenReturn(mockConnectorController);
+        when(mockConnectorController.getStartX()).thenReturn(100.0);
+        when(mockConnectorController.getStartY()).thenReturn(0.0);
+        doNothing().when(mockConnectorController).setStartX(anyDouble());
+        doNothing().when(mockConnectorController).setStartY(anyDouble());
+
+        var args = new ConnectorMovePointCommandArgs(true, -55.0, 30.0, testId);
+        var command = new ConnectorMovePointCommand(args, mockElementIdManager);
+        command.execute();
+
+        verify(mockConnectorController).getStartX();
+        verify(mockConnectorController).getStartY();
+        verify(mockConnectorController).setStartX(45.0);
+        verify(mockConnectorController).setStartY(30.0);
+        verify(mockConnectorController, never()).setEndX(anyDouble());
+        verify(mockConnectorController, never()).setEndY(anyDouble());
+    }
+
+    @Test
+    void executeMoveEndPoint() {
+        long testId = 12L;
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+        when(mockNode.getProperties()).thenReturn(mockPropertiesMap);
+        when(mockPropertiesMap.get("controller")).thenReturn(mockConnectorController);
+        when(mockConnectorController.getEndX()).thenReturn(100.0);
+        when(mockConnectorController.getEndY()).thenReturn(200.0);
+        doNothing().when(mockConnectorController).setEndX(anyDouble());
+        doNothing().when(mockConnectorController).setEndY(anyDouble());
+
+        var args = new ConnectorMovePointCommandArgs(false, 20, 10, testId);
+        var command = new ConnectorMovePointCommand(args, mockElementIdManager);
+        command.execute();
+
+        verify(mockConnectorController).getEndX();
+        verify(mockConnectorController).getEndY();
+        verify(mockConnectorController).setEndX(120.0);
+        verify(mockConnectorController).setEndY(210.0);
+        verify(mockConnectorController, never()).setStartX(anyDouble());
+        verify(mockConnectorController, never()).setStartY(anyDouble());
+    }
+}

--- a/src/test/java/carleton/sysc4907/command/ConnectorMovePointFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ConnectorMovePointFactoryTest.java
@@ -27,6 +27,6 @@ public class ConnectorMovePointFactoryTest {
 
         var command = factory.create(args);
 
-        assertEquals(ConnectorMovePointCommandTest.class, command.getClass());
+        assertEquals(ConnectorMovePointCommand.class, command.getClass());
     }
 }

--- a/src/test/java/carleton/sysc4907/command/ConnectorMovePointFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ConnectorMovePointFactoryTest.java
@@ -1,0 +1,32 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.processing.ElementIdManager;
+import javafx.collections.ObservableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectorMovePointFactoryTest {
+
+    @Mock
+    private ElementIdManager mockElementIdManager;
+
+    @Test
+    void createCommand() {
+        long testId = 12L;
+        Manager mockManager = Mockito.mock(Manager.class);
+        var args = new ConnectorMovePointCommandArgs(false, 20, -30, testId);
+        var factory = new ConnectorMovePointCommandFactory(mockElementIdManager, mockManager);
+
+        var command = factory.create(args);
+
+        assertEquals(ConnectorMovePointCommandTest.class, command.getClass());
+    }
+}

--- a/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
+++ b/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
@@ -27,6 +27,8 @@ public class MessageInterpreterTest {
     private ResizeCommandFactory resizeCommandFactory;
     @Mock
     private EditTextCommandFactory editTextCommandFactory;
+    @Mock
+    private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
 
     @Mock
     private Command<MoveCommandArgs> mockCommand;
@@ -39,7 +41,8 @@ public class MessageInterpreterTest {
                 removeCommandFactory,
                 moveCommandFactory,
                 resizeCommandFactory,
-                editTextCommandFactory
+                editTextCommandFactory,
+                connectorMovePointCommandFactory
         );
         var args = new MoveCommandArgs(0, 0, 1, 1, 0L);
         Mockito.when(moveCommandFactory.create(any(MoveCommandArgs.class))).thenReturn(mockCommand);
@@ -62,7 +65,8 @@ public class MessageInterpreterTest {
                 removeCommandFactory,
                 moveCommandFactory,
                 resizeCommandFactory,
-                editTextCommandFactory
+                editTextCommandFactory,
+                connectorMovePointCommandFactory
         );
         var payload = "Not an args object";
         try (MockedStatic<Platform> platformMockedStatic = Mockito.mockStatic(Platform.class)) {

--- a/src/test/java/carleton/sysc4907/controller/element/ConnectorElementControllerTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/ConnectorElementControllerTest.java
@@ -1,0 +1,174 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.command.ConnectorMovePointCommandFactory;
+import carleton.sysc4907.command.MoveCommandFactory;
+import carleton.sysc4907.controller.element.pathing.PathingStrategy;
+import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectorElementControllerTest {
+
+    @Mock
+    private MovePreviewCreator movePreviewCreator;
+    @Mock
+    private MoveCommandFactory moveCommandFactory;
+    @Mock
+    private DiagramModel diagramModel;
+    @Mock
+    private ConnectorHandleCreator connectorHandleCreator;
+    @Mock
+    private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
+    @Mock
+    private PathingStrategy pathingStrategy;
+    @Mock
+    private ObservableList<DiagramElement> mockSelectedElementsList;
+
+    @Test
+    public void updateDirectionBothSnapped() {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
+        var controller = new ConnectorElementController(
+                movePreviewCreator,
+                moveCommandFactory,
+                diagramModel,
+                connectorHandleCreator,
+                connectorMovePointCommandFactory,
+                pathingStrategy
+        );
+        // Snap to vertical
+        controller.setIsStartHorizontal(false);
+        controller.setIsEndHorizontal(false);
+        controller.setSnapStart(true);
+        controller.setSnapEnd(true);
+
+        // Make the line horizontal, but it shouldn't change because it's snapped
+        controller.setStartX(0);
+        controller.setStartY(0);
+        controller.setEndX(200);
+        controller.setEndY(10);
+        controller.updateDirections();
+
+        Assertions.assertFalse(controller.getIsStartHorizontal());
+        Assertions.assertFalse(controller.getIsEndHorizontal());
+    }
+
+    @Test
+    public void updateDirectionNoneSnappedStraight() {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
+        var controller = new ConnectorElementController(
+                movePreviewCreator,
+                moveCommandFactory,
+                diagramModel,
+                connectorHandleCreator,
+                connectorMovePointCommandFactory,
+                pathingStrategy
+        );
+        // Don't snap
+        controller.setSnapStart(false);
+        controller.setSnapEnd(false);
+
+        // Make the line horizontal, both should be horizontal
+        controller.setStartX(0);
+        controller.setStartY(0);
+        controller.setEndX(200);
+        controller.setEndY(10);
+        controller.updateDirections();
+
+        Assertions.assertTrue(controller.getIsStartHorizontal());
+        Assertions.assertTrue(controller.getIsEndHorizontal());
+    }
+
+    @Test
+    public void updateDirectionNoneSnappedDiagonal() {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
+        var controller = new ConnectorElementController(
+                movePreviewCreator,
+                moveCommandFactory,
+                diagramModel,
+                connectorHandleCreator,
+                connectorMovePointCommandFactory,
+                pathingStrategy
+        );
+        // Don't snap
+        controller.setSnapStart(false);
+        controller.setSnapEnd(false);
+
+        // Make the line diagonal, since neither are snapped we just need the line to not be straight
+        controller.setStartX(0);
+        controller.setStartY(0);
+        controller.setEndX(40);
+        controller.setEndY(30);
+        controller.updateDirections();
+
+        Assertions.assertNotEquals(controller.getIsStartHorizontal(), controller.getIsEndHorizontal());
+    }
+
+    @Test
+    public void updateDirectionOneSnappedStraight() {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
+        var controller = new ConnectorElementController(
+                movePreviewCreator,
+                moveCommandFactory,
+                diagramModel,
+                connectorHandleCreator,
+                connectorMovePointCommandFactory,
+                pathingStrategy
+        );
+        // Snap only start to vertical, shouldn't change
+        controller.setIsStartHorizontal(false);
+        controller.setIsEndHorizontal(false);
+        controller.setSnapStart(true);
+        controller.setSnapEnd(false);
+
+        // Make the line horizontal, the unsnapped end should become horizontal
+        controller.setStartX(0);
+        controller.setStartY(0);
+        controller.setEndX(200);
+        controller.setEndY(10);
+        controller.updateDirections();
+
+        Assertions.assertFalse(controller.getIsStartHorizontal());
+        Assertions.assertTrue(controller.getIsEndHorizontal());
+    }
+
+    @Test
+    public void updateDirectionOneSnappedDiagonal() {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
+        var controller = new ConnectorElementController(
+                movePreviewCreator,
+                moveCommandFactory,
+                diagramModel,
+                connectorHandleCreator,
+                connectorMovePointCommandFactory,
+                pathingStrategy
+        );
+        // Snap only end to vertical, shouldn't change
+        controller.setIsStartHorizontal(false);
+        controller.setIsEndHorizontal(true);
+        controller.setSnapStart(false);
+        controller.setSnapEnd(true);
+
+        // Make the line diagonal, unsnapped end should match snapped end
+        controller.setStartX(0);
+        controller.setStartY(0);
+        controller.setEndX(100);
+        controller.setEndY(120);
+        controller.updateDirections();
+
+        Assertions.assertTrue(controller.getIsStartHorizontal());
+        Assertions.assertTrue(controller.getIsEndHorizontal());
+    }
+}

--- a/src/test/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategyTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategyTest.java
@@ -1,0 +1,2 @@
+package carleton.sysc4907.controller.element.pathing;public class CurvedPathStrategyTest {
+}

--- a/src/test/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategyTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/pathing/CurvedPathStrategyTest.java
@@ -1,2 +1,69 @@
-package carleton.sysc4907.controller.element.pathing;public class CurvedPathStrategyTest {
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CurvedPathStrategyTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void makePathSameDirections(int isHorizontal) {
+        boolean isStartHorizontal = isHorizontal == 0;
+        boolean isEndHorizontal = isStartHorizontal;
+        var startX = 100.0;
+        var startY = 120.0;
+        var endX = 200.0;
+        var endY = 220.0;
+        Path path = new Path();
+        var strategy = new CurvedPathStrategy();
+        strategy.makePath(
+                path,
+                startX, startY, isStartHorizontal,
+                endX, endY, isEndHorizontal);
+
+        var elements = path.getElements();
+        Assertions.assertEquals(2, elements.size());
+        CubicCurveTo line = (CubicCurveTo) elements.get(1);
+        Assertions.assertEquals(endX, line.getX());
+        Assertions.assertEquals(endY, line.getY());
+        if (isStartHorizontal) {
+            Assertions.assertEquals(startY, line.getControlY1());
+            Assertions.assertEquals(endY, line.getControlY2());
+        } else {
+            Assertions.assertEquals(startX, line.getControlX1());
+            Assertions.assertEquals(endX, line.getControlX2());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void makePathDifferentDirections(int isStartHorizontalFlag) {
+        boolean isStartHorizontal = isStartHorizontalFlag == 0;
+        boolean isEndHorizontal = !isStartHorizontal;
+        var startX = 100.0;
+        var startY = 120.0;
+        var endX = 200.0;
+        var endY = 220.0;
+        Path path = new Path();
+        var strategy = new CurvedPathStrategy();
+        strategy.makePath(
+                path,
+                startX, startY, isStartHorizontal,
+                endX, endY, isEndHorizontal);
+
+        var elements = path.getElements();
+        Assertions.assertEquals(2, elements.size());
+        QuadCurveTo line = (QuadCurveTo) elements.get(1);
+        Assertions.assertEquals(endX, line.getX());
+        Assertions.assertEquals(endY, line.getY());
+        if (isStartHorizontal) {
+            Assertions.assertEquals(endX, line.getControlX());
+            Assertions.assertEquals(startY, line.getControlY());
+        } else {
+            Assertions.assertEquals(startX, line.getControlX());
+            Assertions.assertEquals(endY, line.getControlY());
+        }
+    }
 }

--- a/src/test/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategyTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategyTest.java
@@ -1,2 +1,59 @@
-package carleton.sysc4907.controller.element.pathing;public class DirectPathStrategyTest {
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+public class DirectPathStrategyTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void makePathSameDirections(int isHorizontal) {
+        boolean isStartHorizontal = isHorizontal == 0;
+        boolean isEndHorizontal = isStartHorizontal;
+        var startX = 100.0;
+        var startY = 120.0;
+        var endX = 200.0;
+        var endY = 220.0;
+        Path path = new Path();
+        var strategy = new DirectPathStrategy();
+        strategy.makePath(
+                path,
+                startX, startY, isStartHorizontal,
+                endX, endY, isEndHorizontal);
+
+        var elements = path.getElements();
+        Assertions.assertEquals(2, elements.size());
+        LineTo line = (LineTo) elements.get(1);
+        Assertions.assertEquals(endX, line.getX());
+        Assertions.assertEquals(endY, line.getY());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void makePathDifferentDirections(int isStartHorizontalFlag) {
+        boolean isStartHorizontal = isStartHorizontalFlag == 0;
+        boolean isEndHorizontal = !isStartHorizontal;
+        var startX = 100.0;
+        var startY = 120.0;
+        var endX = 200.0;
+        var endY = 220.0;
+        Path path = new Path();
+        var strategy = new DirectPathStrategy();
+        strategy.makePath(
+                path,
+                startX, startY, isStartHorizontal,
+                endX, endY, isEndHorizontal);
+
+        var elements = path.getElements();
+        Assertions.assertEquals(2, elements.size());
+        LineTo line = (LineTo) elements.get(1);
+        Assertions.assertEquals(endX, line.getX());
+        Assertions.assertEquals(endY, line.getY());
+    }
 }

--- a/src/test/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategyTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/pathing/DirectPathStrategyTest.java
@@ -1,0 +1,2 @@
+package carleton.sysc4907.controller.element.pathing;public class DirectPathStrategyTest {
+}

--- a/src/test/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategyTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategyTest.java
@@ -1,0 +1,2 @@
+package carleton.sysc4907.controller.element.pathing;public class OrthogonalPathStrategyTest {
+}

--- a/src/test/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategyTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/pathing/OrthogonalPathStrategyTest.java
@@ -1,2 +1,65 @@
-package carleton.sysc4907.controller.element.pathing;public class OrthogonalPathStrategyTest {
+package carleton.sysc4907.controller.element.pathing;
+
+import javafx.scene.shape.HLineTo;
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.Path;
+import javafx.scene.shape.VLineTo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class OrthogonalPathStrategyTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void makePathSameDirections(int isHorizontal) {
+        boolean isStartHorizontal = isHorizontal == 0;
+        boolean isEndHorizontal = isStartHorizontal;
+        var startX = 100.0;
+        var startY = 120.0;
+        var endX = 200.0;
+        var endY = 220.0;
+        Path path = new Path();
+        var strategy = new OrthogonalPathStrategy();
+        strategy.makePath(
+                path,
+                startX, startY, isStartHorizontal,
+                endX, endY, isEndHorizontal);
+
+        var elements = path.getElements();
+        Assertions.assertEquals(4, elements.size());
+        if (isStartHorizontal) {
+            Assertions.assertEquals(HLineTo.class, elements.get(1).getClass());
+            Assertions.assertEquals(VLineTo.class, elements.get(2).getClass());
+        } else {
+            Assertions.assertEquals(VLineTo.class, elements.get(1).getClass());
+            Assertions.assertEquals(HLineTo.class, elements.get(2).getClass());
+        }
+        LineTo line = (LineTo) elements.get(3);
+        Assertions.assertEquals(endX, line.getX());
+        Assertions.assertEquals(endY, line.getY());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void makePathDifferentDirections(int isStartHorizontalFlag) {
+        boolean isStartHorizontal = isStartHorizontalFlag == 0;
+        boolean isEndHorizontal = !isStartHorizontal;
+        var startX = 100.0;
+        var startY = 120.0;
+        var endX = 200.0;
+        var endY = 220.0;
+        Path path = new Path();
+        var strategy = new OrthogonalPathStrategy();
+        strategy.makePath(
+                path,
+                startX, startY, isStartHorizontal,
+                endX, endY, isEndHorizontal);
+
+        var elements = path.getElements();
+        Assertions.assertEquals(3, elements.size());
+        LineTo line = (LineTo) elements.get(2);
+        Assertions.assertEquals(endX, line.getX());
+        Assertions.assertEquals(endY, line.getY());
+    }
 }

--- a/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
@@ -1,0 +1,49 @@
+package carleton.sysc4907.ui.view;
+
+import carleton.sysc4907.controller.element.ConnectorElementController;
+import carleton.sysc4907.controller.element.ConnectorHandleCreator;
+import carleton.sysc4907.controller.element.pathing.OrthogonalPathStrategy;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.stage.Stage;
+import org.testfx.framework.junit5.Start;
+
+import java.io.IOException;
+
+public class ConnectorTest extends DiagramElementTest {
+
+    private ConnectorHandleCreator connectorHandleCreator;
+
+    @Start
+    @Override
+    protected void start(Stage stage) throws IOException {
+        connectorHandleCreator = new ConnectorHandleCreator();
+        super.start(stage);
+    }
+
+    /**
+     * Adds additional injection methods, such as for the controller of the diagram element under test.
+     */
+    @Override
+    protected void addInjectionMethods() {
+        dependencyInjector.addInjectionMethod(ConnectorElementController.class,
+                () -> new ConnectorElementController(movePreviewCreator,
+                        moveCommandFactory,
+                        diagramModel,
+                        connectorHandleCreator,
+                        new OrthogonalPathStrategy()));
+    }
+
+    /**
+     * Loads the diagram element under test.
+     *
+     * @return the DiagramElement to test
+     */
+    @Override
+    protected DiagramElement loadElement() {
+        try {
+            return (DiagramElement) dependencyInjector.load("view/element/Connector.fxml");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
@@ -1,5 +1,6 @@
 package carleton.sysc4907.ui.view;
 
+import carleton.sysc4907.command.ConnectorMovePointCommandFactory;
 import carleton.sysc4907.controller.element.ConnectorElementController;
 import carleton.sysc4907.controller.element.ConnectorHandleCreator;
 import carleton.sysc4907.controller.element.pathing.OrthogonalPathStrategy;
@@ -12,11 +13,13 @@ import java.io.IOException;
 public class ConnectorTest extends DiagramElementTest {
 
     private ConnectorHandleCreator connectorHandleCreator;
+    private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
 
     @Start
     @Override
     protected void start(Stage stage) throws IOException {
         connectorHandleCreator = new ConnectorHandleCreator();
+        connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(elementIdManager, mockManager);
         super.start(stage);
     }
 
@@ -30,6 +33,7 @@ public class ConnectorTest extends DiagramElementTest {
                         moveCommandFactory,
                         diagramModel,
                         connectorHandleCreator,
+                        connectorMovePointCommandFactory,
                         new OrthogonalPathStrategy()));
     }
 


### PR DESCRIPTION
Features:
- Connector elements with movable start and endpoints. They support all the default element behavior (moving, selecting, deleting), plus moving each endpoint separately. The connector doesn't have arrowheads etc but those can be added later.
- Commands for moving the endpoint of a connector, so that this can be transferred over TCP.
- Three different types of pathing: direct, orthogonal, and curved. There is an unused way to change which is used for a given line, currently they're all created as curved for testing purposes.
- Some support for snapping. Once we're able to snap a point to somewhere and tell whether the line should go horizontally or vertically from that point, the connector will path correctly.

Tests:
- Unit tests for pathing strategies
- Unit tests for the new command
- Functional tests for previous functionality on the new connector element
- Functional tests for connector elements, for moving the start and endpoints via click + drag