### PR TITLE
Fix bug where editable labels would stay focused

### DIFF
--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -59,6 +59,7 @@ public abstract class DiagramElementController {
         addMouseHandler(MouseEvent.MOUSE_DRAGGED, this::handleMouseDraggedMovePreview);
         addMouseHandler(MouseEvent.MOUSE_RELEASED, this::handleMouseReleasedDeletePreview);
         addMouseHandler(MouseEvent.MOUSE_PRESSED, this::handleSelect);
+        addMouseHandler(MouseEvent.MOUSE_PRESSED, (evt) -> element.requestFocus());
     }
 
     /**


### PR DESCRIPTION
One-line fix to resolve #84.

The alternative would be to find some way to _not_ consume() click events, which leads to difficulties because events will be sent to the editing area and cause de-selecting.

Implication: future "sub-element" controllers such as the editable label should not consume() events, **unless** they plan to request focus manually in their handler.