### PR TITLE
Remove previews when an element is deleted

### DIFF
--- a/src/main/java/carleton/sysc4907/command/RemoveCommand.java
+++ b/src/main/java/carleton/sysc4907/command/RemoveCommand.java
@@ -3,6 +3,7 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
+import carleton.sysc4907.controller.element.DiagramElementController;
 import carleton.sysc4907.model.DiagramModel;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
@@ -32,15 +33,22 @@ public class RemoveCommand implements Command<RemoveCommandArgs> {
     public void execute() {
         Pane editingArea = EditingAreaProvider.getEditingArea();
         List<DiagramElement> elements = new LinkedList<>();
+        List<DiagramElementController> controllers = new LinkedList<>();
         for (long id : args.elementIds()) {
             var element = (DiagramElement) elementIdManager.getElementById(id);
             if (element != null) {
                 elements.add(element);
             }
+            var controller = elementIdManager.getElementControllerById(id);
+            if (controller != null) {
+                controllers.add(controller);
+            }
         }
-        if (elements.isEmpty()) {
+        if (elements.isEmpty() && controllers.isEmpty()) {
             return;
         }
+
+        controllers.forEach(DiagramElementController::deletePreviews);
         editingArea.getChildren().removeAll(elements);
         diagramModel.getElements().removeAll(elements);
         diagramModel.getSelectedElements().clear();

--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -87,6 +87,15 @@ public abstract class DiagramElementController {
     }
 
     /**
+     * Deletes all previews related to this element. Should be called when this element is deleted.
+     * Subclasses should override this if they add any previews that aren't placed as children of the element itself.
+     * Does nothing if there are no previews for this element.
+     */
+    public void deletePreviews() {
+        previewCreator.deleteMovePreview(element, preview);
+    }
+
+    /**
      * Creates a move preview by taking a screenshot of the element. Also handles any preparation before and after it,
      * to ensure that the preview is the same size as the actual element.
      * @return the preview element as an ImageView

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -28,9 +28,6 @@ public abstract class ResizableElementController extends DiagramElementControlle
     private final ResizeCommandFactory resizeCommandFactory;
     private final ResizePreviewCreator resizePreviewCreator;
     private Pane preview = null;
-
-
-
     private double resizeDragStartX = 0;
     private double resizeDragStartY = 0;
     private double lastPreviewDragX = 0;
@@ -81,6 +78,12 @@ public abstract class ResizableElementController extends DiagramElementControlle
             toggleShowResizeHandles(!showHandles);
             toggleShowResizeHandles(showHandles);
         });
+    }
+
+    @Override
+    public void deletePreviews() {
+        super.deletePreviews();
+        resizePreviewCreator.deleteResizePreview(element, preview);
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
+++ b/src/main/java/carleton/sysc4907/processing/ElementIdManager.java
@@ -1,6 +1,7 @@
 package carleton.sysc4907.processing;
 
 import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.controller.element.DiagramElementController;
 import carleton.sysc4907.model.SessionModel;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -88,6 +89,21 @@ public class ElementIdManager {
     public Node getElementById(Long id) {
         Parent parent = EditingAreaProvider.getEditingArea();
         return getElementByIdInParent(parent, id);
+    }
+
+    /**
+     * Gets the element controller for the element in the diagram with the given ID, if it exists.
+     * If the ID exists but represents a non-DiagramElement object such as a preview, returns null.
+     * @param id the ID to get the controller for
+     * @return the controller if the DiagramElement exists and has one, null otherwise
+     */
+    public DiagramElementController getElementControllerById(Long id) {
+        var node = getElementById(id);
+        if (node == null) return null;
+        var controller = node.getProperties().get("controller");
+        if (controller == null) return null;
+        if (!(controller instanceof DiagramElementController)) return null;
+        return (DiagramElementController) controller;
     }
 
     private Node getElementByIdInParent(Parent parent, Long id) {

--- a/src/main/resources/carleton/sysc4907/view/element/Rectangle.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/Rectangle.fxml
@@ -6,5 +6,9 @@
                 xmlns:fx="http://javafx.com/fxml"
                 fx:controller="carleton.sysc4907.controller.element.RectangleController"
                 maxWidth="200" maxHeight="100">
+    <properties>
+        <!-- Set controller as property so commands can find it-->
+        <controller><fx:reference source="controller"/></controller>
+    </properties>
     <Rectangle styleClass="diagram-background-element" fx:id="rect"/>
 </DiagramElement>

--- a/src/main/resources/carleton/sysc4907/view/element/UmlClass.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/UmlClass.fxml
@@ -14,6 +14,10 @@
                 xmlns:fx="http://javafx.com/fxml"
                 fx:controller="carleton.sysc4907.controller.element.UmlClassController"
                 maxHeight="200" maxWidth="150">
+    <properties>
+        <!-- Set controller as property so commands can find it-->
+        <controller><fx:reference source="controller"/></controller>
+    </properties>
     <StackPane fx:id="bgStackPane">
         <Rectangle styleClass="diagram-UML-class-element" fx:id="background"/>
         <VBox>

--- a/src/main/resources/carleton/sysc4907/view/element/UmlComment.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/UmlComment.fxml
@@ -7,6 +7,10 @@
                 xmlns:fx="http://javafx.com/fxml"
                 fx:controller="carleton.sysc4907.controller.element.UmlCommentController"
                 maxHeight="100" maxWidth="200">
+    <properties>
+        <!-- Set controller as property so commands can find it-->
+        <controller><fx:reference source="controller"/></controller>
+    </properties>
     <StackPane fx:id="stackPane">
         <Rectangle styleClass="diagram-background-element" fx:id="background"/>
         <fx:include source="EditableLabel.fxml" fx:id="editableLabel"/>

--- a/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
+++ b/src/test/java/carleton/sysc4907/processing/ElementIdManagerTest.java
@@ -1,10 +1,12 @@
 package carleton.sysc4907.processing;
 
 import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.controller.element.DiagramElementController;
 import carleton.sysc4907.model.SessionModel;
 import carleton.sysc4907.model.User;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.layout.Pane;
@@ -19,8 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.LinkedList;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ElementIdManagerTest {
@@ -40,6 +41,11 @@ public class ElementIdManagerTest {
     @Mock
     private Pane mockEditingArea;
 
+    @Mock
+    private ObservableMap<Object, Object> mockProperties;
+    @Mock
+    private DiagramElementController mockElementController;
+
     private final String testUserId = "testlongid";
     private final long testNodeId = 1L;
 
@@ -51,6 +57,7 @@ public class ElementIdManagerTest {
         lenient().when(mockSessionModel.getLocalUser()).thenReturn(mockUser);
         lenient().when(mockUser.getUsername()).thenReturn(testUserId);
         lenient().when(mockNode.getUserData()).thenReturn(testNodeId);
+        lenient().when(mockNode.getProperties()).thenReturn(mockProperties);
     }
 
     @Test
@@ -108,6 +115,41 @@ public class ElementIdManagerTest {
             nodes.add(mockNode);
             when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
             assertNull(elementIdManager.getElementById(201L));
+        }
+    }
+
+    @Test
+    public void getElementControllerByIdExists() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            when(mockProperties.get("controller")).thenReturn(mockElementController);
+            assertEquals(mockElementController, elementIdManager.getElementControllerById(testNodeId));
+        }
+    }
+
+    @Test
+    public void getElementControllerByIdNoElement() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            assertNull(elementIdManager.getElementControllerById(201L));
+        }
+    }
+
+    @Test
+    public void getElementControllerByIdNoController() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ObservableList<Node> nodes = FXCollections.observableList(new LinkedList<>());
+            nodes.add(mockNode);
+            when(mockEditingArea.getChildrenUnmodifiable()).thenReturn(nodes);
+            when(mockProperties.get("controller")).thenReturn(null);
+            assertNull(elementIdManager.getElementControllerById(testNodeId));
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Andrei486/uml-diagram-collab/issues/72.

Needs testing with multiple users. Tested locally by alt-tabbing during move and resize operations, which keeps the previews open, and then deleting the element without resuming the operation. The preview is deleted in both cases as expected.

This change requires that from now on, all FXMLs corresponding to DiagramElements expose their controller in the node's properties - previously only the connector did for different reasons. Without this, the preview removal will not work, but nothing should break.

Example of how to expose the controller in FXML:
``` 
<properties>
    <!-- Set controller as property so commands can find it-->
    <controller><fx:reference source="controller"/></controller>
</properties>```

The element ID manager has been updated so it can find controllers from IDs, and the remove command uses this to remove all previews from the removed elements before removing the elements themselves.