### PR TITLE
Make move/resize absolute again

### DIFF
--- a/src/main/java/carleton/sysc4907/command/MoveCommand.java
+++ b/src/main/java/carleton/sysc4907/command/MoveCommand.java
@@ -22,8 +22,8 @@ public class MoveCommand implements Command<MoveCommandArgs> {
     public void execute() {
         var element = elementIdManager.getElementById(args.elementId());
         if (element == null) return;
-        element.setLayoutX(args.endX() - args.startX() + element.getLayoutX());
-        element.setLayoutY(args.endY() - args.startY() + element.getLayoutY());
+        element.setLayoutX(args.endX() - args.startX());
+        element.setLayoutY(args.endY() - args.startY());
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/command/ResizeCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommand.java
@@ -1,9 +1,7 @@
 package carleton.sysc4907.command;
 
-import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.ResizeCommandArgs;
 import carleton.sysc4907.processing.ElementIdManager;
-import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.layout.Pane;
 
 public class ResizeCommand implements Command<ResizeCommandArgs> {
@@ -28,6 +26,8 @@ public class ResizeCommand implements Command<ResizeCommandArgs> {
         var dragEndY = args.dragEndY();
         var isTopAnchor = args.isTopAnchor();
         var isRightAnchor = args.isRightAnchor();
+        var elementX = args.elementX();
+        var elementY = args.elementY();
         var width = args.width();
         var height = args.height();
 
@@ -42,10 +42,10 @@ public class ResizeCommand implements Command<ResizeCommandArgs> {
         element.setMaxHeight(height + heightChange);
         // The move part can be relative, we don't want to move the element back during a resize
         if (isTopAnchor) {
-            element.setLayoutY(element.getLayoutY() - heightChange);
+            element.setLayoutY(elementY - heightChange);
         }
         if (!isRightAnchor) {
-            element.setLayoutX(element.getLayoutX() - widthChange);
+            element.setLayoutX(elementX - widthChange);
         }
     }
 

--- a/src/main/java/carleton/sysc4907/command/ResizeCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommand.java
@@ -28,15 +28,19 @@ public class ResizeCommand implements Command<ResizeCommandArgs> {
         var dragEndY = args.dragEndY();
         var isTopAnchor = args.isTopAnchor();
         var isRightAnchor = args.isRightAnchor();
+        var width = args.width();
+        var height = args.height();
 
         double widthChange = dragEndX - dragStartX;
         widthChange = isRightAnchor ? widthChange : -widthChange;
-        widthChange = Math.max(widthChange, -element.getMaxWidth() + 20);
+        widthChange = Math.max(widthChange, -width + 20);
         double heightChange = dragEndY - dragStartY;
         heightChange = isTopAnchor ? -heightChange : heightChange;
-        heightChange = Math.max(heightChange, -element.getMaxHeight() + 20);
-        element.setMaxWidth(element.getMaxWidth() + widthChange);
-        element.setMaxHeight(element.getMaxHeight() + heightChange);
+        heightChange = Math.max(heightChange, -height + 20);
+        // Use previous width and height values to make the command absolute
+        element.setMaxWidth(width + widthChange);
+        element.setMaxHeight(height + heightChange);
+        // The move part can be relative, we don't want to move the element back during a resize
         if (isTopAnchor) {
             element.setLayoutY(element.getLayoutY() - heightChange);
         }

--- a/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
@@ -1,7 +1,5 @@
 package carleton.sysc4907.command.args;
 
-import javafx.scene.layout.Pane;
-
 import java.io.Serializable;
 
 public record ResizeCommandArgs(boolean isTopAnchor,
@@ -10,6 +8,8 @@ public record ResizeCommandArgs(boolean isTopAnchor,
                                 double dragStartY,
                                 double dragEndX,
                                 double dragEndY,
+                                double elementX,
+                                double elementY,
                                 double width,
                                 double height,
                                 long elementId) implements Serializable {

--- a/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ResizeCommandArgs.java
@@ -10,6 +10,8 @@ public record ResizeCommandArgs(boolean isTopAnchor,
                                 double dragStartY,
                                 double dragEndX,
                                 double dragEndY,
+                                double width,
+                                double height,
                                 long elementId) implements Serializable {
 
 }

--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -145,8 +145,8 @@ public abstract class DiagramElementController {
             return;
         }
         dragging = true;
-        dragStartX = event.getSceneX();
-        dragStartY = event.getSceneY();
+        dragStartX = event.getSceneX() - element.getLayoutX();
+        dragStartY = event.getSceneY() - element.getLayoutY();
         previewCreator.deleteMovePreview(element, preview);
         preview = takeMovePreviewImage();
     }
@@ -157,8 +157,8 @@ public abstract class DiagramElementController {
             return;
         }
         if (preview != null) {
-            double dragEndX = event.getSceneX() + element.getLayoutX() - preview.getLayoutX();
-            double dragEndY = event.getSceneY() + element.getLayoutY() - preview.getLayoutY();
+            double dragEndX = event.getSceneX();
+            double dragEndY = event.getSceneY();
             MoveCommandArgs args = new MoveCommandArgs(
                     dragStartX, dragStartY,
                     dragEndX, dragEndY,

--- a/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/MovePreviewCreator.java
@@ -26,7 +26,7 @@ public class MovePreviewCreator {
     /**
      * Creates a semi-transparent move preview for a given element and adds it to the diagram editing pane.
      * @param element the DiagramElement to preview the movement of
-     * @param dragStartX the x coordinate where dragging started
+     * @param dragStartX the elementX coordinate where dragging started
      * @param dragStartY the y coordinate where dragging started
      * @return the created preview as an ImageView
      */

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -155,6 +155,8 @@ public abstract class ResizableElementController extends DiagramElementControlle
                     resizeDragStartY,
                     event.getSceneX(),
                     event.getSceneY(),
+                    preview.getLayoutX(),
+                    preview.getLayoutY(),
                     preview.getMaxWidth(),
                     preview.getMaxHeight(),
                     (long) preview.getUserData()
@@ -182,6 +184,8 @@ public abstract class ResizableElementController extends DiagramElementControlle
                 resizeDragStartY,
                 event.getSceneX(),
                 event.getSceneY(),
+                element.getLayoutX(),
+                element.getLayoutY(),
                 element.getMaxWidth(),
                 element.getMaxHeight(),
                 element.getElementId()

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -68,16 +68,6 @@ public abstract class ResizableElementController extends DiagramElementControlle
     @Override
     public void initialize() {
         super.initialize();
-//        element.maxWidthProperty().addListener((observableValue, number, t1) -> {
-//            boolean showHandles = diagramModel.getSelectedElements().contains(element);
-//            toggleShowResizeHandles(!showHandles);
-//            toggleShowResizeHandles(showHandles);
-//        });
-//        element.maxHeightProperty().addListener((observableValue, number, t1) -> {
-//            boolean showHandles = diagramModel.getSelectedElements().contains(element);
-//            toggleShowResizeHandles(!showHandles);
-//            toggleShowResizeHandles(showHandles);
-//        });
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -155,6 +155,8 @@ public abstract class ResizableElementController extends DiagramElementControlle
                     resizeDragStartY,
                     event.getSceneX(),
                     event.getSceneY(),
+                    preview.getMaxWidth(),
+                    preview.getMaxHeight(),
                     (long) preview.getUserData()
             );
             // this is not a tracked command because it's the preview,
@@ -180,6 +182,8 @@ public abstract class ResizableElementController extends DiagramElementControlle
                 resizeDragStartY,
                 event.getSceneX(),
                 event.getSceneY(),
+                element.getMaxWidth(),
+                element.getMaxHeight(),
                 element.getElementId()
         ));
         command.execute();

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -68,16 +68,16 @@ public abstract class ResizableElementController extends DiagramElementControlle
     @Override
     public void initialize() {
         super.initialize();
-        element.maxWidthProperty().addListener((observableValue, number, t1) -> {
-            boolean showHandles = diagramModel.getSelectedElements().contains(element);
-            toggleShowResizeHandles(!showHandles);
-            toggleShowResizeHandles(showHandles);
-        });
-        element.maxHeightProperty().addListener((observableValue, number, t1) -> {
-            boolean showHandles = diagramModel.getSelectedElements().contains(element);
-            toggleShowResizeHandles(!showHandles);
-            toggleShowResizeHandles(showHandles);
-        });
+//        element.maxWidthProperty().addListener((observableValue, number, t1) -> {
+//            boolean showHandles = diagramModel.getSelectedElements().contains(element);
+//            toggleShowResizeHandles(!showHandles);
+//            toggleShowResizeHandles(showHandles);
+//        });
+//        element.maxHeightProperty().addListener((observableValue, number, t1) -> {
+//            boolean showHandles = diagramModel.getSelectedElements().contains(element);
+//            toggleShowResizeHandles(!showHandles);
+//            toggleShowResizeHandles(showHandles);
+//        });
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/controller/element/ResizeHandleCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizeHandleCreator.java
@@ -16,8 +16,6 @@ public class ResizeHandleCreator {
     }
 
     public Node createResizeHandle(DiagramElement element, boolean isTop, boolean isRight) {
-        double posX = isRight ? element.getMaxWidth() - HANDLE_SIZE : 0;
-        double posY = isTop ? 0 : element.getMaxHeight() - HANDLE_SIZE;
         FXMLLoader loader = new FXMLLoader();
         loader.setLocation(ResizeHandleCreator.class.getResource("/carleton/sysc4907/view/element/ResizeHandle.fxml"));
         Rectangle resizeHandle = null;
@@ -27,8 +25,16 @@ public class ResizeHandleCreator {
             throw new RuntimeException(e);
         }
         element.getChildren().add(resizeHandle);
-        resizeHandle.setLayoutX(posX);
-        resizeHandle.setLayoutY(posY);
+        if (isRight) {
+            resizeHandle.layoutXProperty().bind(element.maxWidthProperty().subtract(HANDLE_SIZE));
+        } else {
+            resizeHandle.layoutXProperty().set(0);
+        }
+        if (!isTop) {
+            resizeHandle.layoutYProperty().bind(element.maxHeightProperty().subtract(HANDLE_SIZE));
+        } else {
+            resizeHandle.layoutYProperty().set(0);
+        }
         return resizeHandle;
     }
 

--- a/src/test/java/carleton/sysc4907/command/MoveCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/MoveCommandTest.java
@@ -33,4 +33,46 @@ public class MoveCommandTest {
         verify(mockNode).setLayoutX(30);
         verify(mockNode).setLayoutY(-30);
     }
+
+    @Test
+    void executeMoveIdempotent() {
+        long testId = 12L;
+        doNothing().when(mockNode).setLayoutX(30);
+        doNothing().when(mockNode).setLayoutY(-30);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+
+        MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, testId);
+        MoveCommand command = new MoveCommand(args, mockElementIdManager);
+
+        command.execute();
+        command.execute();
+
+        verify(mockNode, times(2)).setLayoutX(30);
+        verify(mockNode, times(2)).setLayoutY(-30);
+    }
+
+    @Test
+    void executeMoveAbsolute() {
+        long testId = 12L;
+        doNothing().when(mockNode).setLayoutX(30);
+        doNothing().when(mockNode).setLayoutY(-30);
+        doNothing().when(mockNode).setLayoutX(60);
+        doNothing().when(mockNode).setLayoutY(-60);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+
+        MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, testId);
+        MoveCommandArgs args2 = new MoveCommandArgs(10, 0, 70, -60, testId);
+        MoveCommand command = new MoveCommand(args, mockElementIdManager);
+        MoveCommand command2 = new MoveCommand(args2, mockElementIdManager);
+
+        command2.execute();
+
+        verify(mockNode).setLayoutX(60);
+        verify(mockNode).setLayoutY(-60);
+
+        command.execute();
+
+        verify(mockNode).setLayoutX(30);
+        verify(mockNode).setLayoutY(-30);
+    }
 }

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
@@ -27,7 +27,7 @@ public class ResizeCommandFactoryTest {
         long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
         ResizeCommandArgs args = new ResizeCommandArgs(true, true,
-                10, 0, 40, -30, 100, 200, testId);
+                10, 0, 40, -30, 0, 0, 100, 200, testId);
         Manager mockManager = Mockito.mock(Manager.class);
         ResizeCommandFactory factory = new ResizeCommandFactory(mockElementIdManager, mockManager);
 

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
@@ -27,7 +27,7 @@ public class ResizeCommandFactoryTest {
         long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
         ResizeCommandArgs args = new ResizeCommandArgs(true, true,
-                10, 0, 40, -30, testId);
+                10, 0, 40, -30, 100, 200, testId);
         Manager mockManager = Mockito.mock(Manager.class);
         ResizeCommandFactory factory = new ResizeCommandFactory(mockElementIdManager, mockManager);
 

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
@@ -28,7 +28,7 @@ public class ResizeCommandTest {
         doNothing().when(mockNode).setMaxHeight(70.0);
         when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(false, true,
-                10, 0, 40, -30, 100, 100, testId);
+                10, 0, 40, -30, 0, 0, 100, 100, testId);
         ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
 
         command.execute();
@@ -47,7 +47,7 @@ public class ResizeCommandTest {
         doNothing().when(mockNode).setMaxHeight(70.0);
         when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(false, true,
-                10, 0, 40, -30, 100, 100, testId);
+                10, 0, 40, -30, 0, 0, 100, 100, testId);
         ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
 
         command.execute();
@@ -69,9 +69,9 @@ public class ResizeCommandTest {
         doNothing().when(mockNode).setMaxHeight(40.0);
         when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(false, true,
-                10, 0, 40, -30, 100, 100, testId);
+                10, 0, 40, -30, 0, 0, 100, 100, testId);
         ResizeCommandArgs args2 = new ResizeCommandArgs(false, true,
-                10, 0, 70, -60, 100, 100, testId);
+                10, 0, 70, -60, 0, 0, 100, 100, testId);
         ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
         ResizeCommand command2 = new ResizeCommand(args2, mockElementIdManager);
 
@@ -92,13 +92,11 @@ public class ResizeCommandTest {
     void executeResizeTopLeft() {
         long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
-        Mockito.when(mockNode.getLayoutX()).thenReturn(0.0);
-        Mockito.when(mockNode.getLayoutY()).thenReturn(0.0);
         doNothing().when(mockNode).setMaxWidth(130.0);
         doNothing().when(mockNode).setMaxHeight(70.0);
         when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(true, false,
-                10, 0, -20, 30, 100, 100, testId);
+                10, 0, -20, 30, 0, 0, 100, 100, testId);
         ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
 
         command.execute();

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandTest.java
@@ -24,14 +24,61 @@ public class ResizeCommandTest {
     void executeResizeBottomRight() {
         long testId = 12L;
         Pane mockNode = Mockito.mock(Pane.class);
-        Mockito.when(mockNode.getMaxHeight()).thenReturn(100.0);
-        Mockito.when(mockNode.getMaxWidth()).thenReturn(100.0);
         doNothing().when(mockNode).setMaxWidth(130.0);
         doNothing().when(mockNode).setMaxHeight(70.0);
         when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(false, true,
-                10, 0, 40, -30, testId);
+                10, 0, 40, -30, 100, 100, testId);
         ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
+
+        command.execute();
+
+        verify(mockNode, never()).setLayoutX(Mockito.anyDouble());
+        verify(mockNode, never()).setLayoutX(Mockito.anyDouble());
+        verify(mockNode).setMaxWidth(130.0);
+        verify(mockNode).setMaxHeight(70.0);
+    }
+
+    @Test
+    void executeResizeIdempotent() {
+        long testId = 12L;
+        Pane mockNode = Mockito.mock(Pane.class);
+        doNothing().when(mockNode).setMaxWidth(130.0);
+        doNothing().when(mockNode).setMaxHeight(70.0);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+        ResizeCommandArgs args = new ResizeCommandArgs(false, true,
+                10, 0, 40, -30, 100, 100, testId);
+        ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
+
+        command.execute();
+        command.execute();
+
+        verify(mockNode, never()).setLayoutX(Mockito.anyDouble());
+        verify(mockNode, never()).setLayoutX(Mockito.anyDouble());
+        verify(mockNode, times(2)).setMaxWidth(130.0);
+        verify(mockNode, times(2)).setMaxHeight(70.0);
+    }
+
+    @Test
+    void executeResizeAbsolute() {
+        long testId = 12L;
+        Pane mockNode = Mockito.mock(Pane.class);
+        doNothing().when(mockNode).setMaxWidth(130.0);
+        doNothing().when(mockNode).setMaxHeight(70.0);
+        doNothing().when(mockNode).setMaxWidth(160.0);
+        doNothing().when(mockNode).setMaxHeight(40.0);
+        when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
+        ResizeCommandArgs args = new ResizeCommandArgs(false, true,
+                10, 0, 40, -30, 100, 100, testId);
+        ResizeCommandArgs args2 = new ResizeCommandArgs(false, true,
+                10, 0, 70, -60, 100, 100, testId);
+        ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
+        ResizeCommand command2 = new ResizeCommand(args2, mockElementIdManager);
+
+        command2.execute();
+
+        verify(mockNode).setMaxWidth(160.0);
+        verify(mockNode).setMaxHeight(40.0);
 
         command.execute();
 
@@ -47,13 +94,11 @@ public class ResizeCommandTest {
         Pane mockNode = Mockito.mock(Pane.class);
         Mockito.when(mockNode.getLayoutX()).thenReturn(0.0);
         Mockito.when(mockNode.getLayoutY()).thenReturn(0.0);
-        Mockito.when(mockNode.getMaxHeight()).thenReturn(100.0);
-        Mockito.when(mockNode.getMaxWidth()).thenReturn(100.0);
         doNothing().when(mockNode).setMaxWidth(130.0);
         doNothing().when(mockNode).setMaxHeight(70.0);
         when(mockElementIdManager.getElementById(testId)).thenReturn(mockNode);
         ResizeCommandArgs args = new ResizeCommandArgs(true, false,
-                10, 0, -20, 30, testId);
+                10, 0, -20, 30, 100, 100, testId);
         ResizeCommand command = new ResizeCommand(args, mockElementIdManager);
 
         command.execute();


### PR DESCRIPTION
Resolves #94.

This PR makes move and resize commands absolute, so they overwrite previous ones run.
A side effect of this is that resize commands that aren't from the bottom right include a move which is now absolute - in these cases the resize will also overwrite previous moves.