### PR TITLE
Add command list and remote commands

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -88,6 +88,7 @@ public class DiagramEditorLoader {
         ElementIdManager elementIdManager = new ElementIdManager(sessionModel);
         TextFormattingModel textFormattingModel = new TextFormattingModel(fontOptionsFinder);
         DiagramModel diagramModel = new DiagramModel();
+        ExecutedCommandList executedCommandList = new ExecutedCommandList();
         MovePreviewCreator movePreviewCreator = new MovePreviewCreator(elementIdManager);
         ResizeHandleCreator resizeHandleCreator = new ResizeHandleCreator();
         ResizePreviewCreator resizePreviewCreator = new ResizePreviewCreator(elementIdManager);
@@ -102,12 +103,18 @@ public class DiagramEditorLoader {
             throw new RuntimeException(e);
         }
 
-        MoveCommandFactory moveCommandFactory = new MoveCommandFactory(elementIdManager, manager);
-        ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory(elementIdManager, manager);
-        AddCommandFactory addCommandFactory = new AddCommandFactory(diagramModel, elementCreator, manager);
-        RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(diagramModel, elementIdManager, manager);
-        EditTextCommandFactory editTextCommandFactory = new EditTextCommandFactory(elementIdManager, manager);
-        ConnectorMovePointCommandFactory connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(elementIdManager, manager);
+        MoveCommandFactory moveCommandFactory = new MoveCommandFactory(
+                elementIdManager, manager, executedCommandList);
+        ResizeCommandFactory resizeCommandFactory = new ResizeCommandFactory(
+                elementIdManager, manager, executedCommandList);
+        AddCommandFactory addCommandFactory = new AddCommandFactory(
+                diagramModel, elementCreator, manager, executedCommandList);
+        RemoveCommandFactory removeCommandFactory = new RemoveCommandFactory(
+                diagramModel, elementIdManager, manager, executedCommandList);
+        EditTextCommandFactory editTextCommandFactory = new EditTextCommandFactory(
+                elementIdManager, manager, executedCommandList);
+        ConnectorMovePointCommandFactory connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(
+                elementIdManager, manager, executedCommandList);
         // Add factories to message interpreter: avoids circular dependencies
         interpreter.addFactories(
                 addCommandFactory,
@@ -147,7 +154,7 @@ public class DiagramEditorLoader {
         injector.addInjectionMethod(SessionUsersMenuController.class,
                 () -> new SessionUsersMenuController(sessionModel));
         injector.addInjectionMethod(DiagramMenuBarController.class,
-                () -> new DiagramMenuBarController(diagramModel, removeCommandFactory));
+                () -> new DiagramMenuBarController(diagramModel, removeCommandFactory, executedCommandList));
         injector.addInjectionMethod(DiagramEditingAreaController.class,
                 () -> new DiagramEditingAreaController(diagramModel));
         injector.addInjectionMethod(ElementLibraryPanelController.class,

--- a/src/main/java/carleton/sysc4907/command/AddCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/AddCommandFactory.java
@@ -4,14 +4,16 @@ import carleton.sysc4907.DependencyInjector;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementCreator;
 
 public class AddCommandFactory extends TrackedCommandFactory<Command<AddCommandArgs>, AddCommandArgs> {
     private final DiagramModel diagramModel;
     private final ElementCreator elementCreator;
 
-    public AddCommandFactory(DiagramModel diagramModel, ElementCreator elementCreator, Manager manager) {
-        super(manager);
+    public AddCommandFactory(DiagramModel diagramModel, ElementCreator elementCreator,
+                             Manager manager, ExecutedCommandList executedCommandList) {
+        super(manager, executedCommandList);
         this.diagramModel = diagramModel;
         this.elementCreator = elementCreator;
     }

--- a/src/main/java/carleton/sysc4907/command/CommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/CommandFactory.java
@@ -20,4 +20,11 @@ public interface CommandFactory<T extends Command<TArgs>, TArgs> {
      * @return a tracked command that wraps a command of the specified type
      */
     Command<TArgs> createTracked(TArgs args);
+
+    /**
+     * Creates a remote command object, for commands received via TCP.
+     * @param args the arguments for the remote command
+     * @return a remote command wrapping a command of the specified type
+     */
+    Command<TArgs> createRemote(TArgs args);
 }

--- a/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/ConnectorMovePointCommandFactory.java
@@ -2,14 +2,16 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 
 public class ConnectorMovePointCommandFactory extends TrackedCommandFactory<Command<ConnectorMovePointCommandArgs>, ConnectorMovePointCommandArgs> {
 
     private final ElementIdManager elementIdManager;
 
-    public ConnectorMovePointCommandFactory(ElementIdManager elementIdManager, Manager manager) {
-        super(manager);
+    public ConnectorMovePointCommandFactory(ElementIdManager elementIdManager,
+                                            Manager manager, ExecutedCommandList executedCommandList) {
+        super(manager, executedCommandList);
         this.elementIdManager = elementIdManager;
     }
 

--- a/src/main/java/carleton/sysc4907/command/EditTextCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/EditTextCommandFactory.java
@@ -3,14 +3,16 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.EditTextCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 
 public class EditTextCommandFactory extends TrackedCommandFactory<Command<EditTextCommandArgs>, EditTextCommandArgs> {
 
     private final ElementIdManager elementIdManager;
 
-    public EditTextCommandFactory(ElementIdManager elementIdManager, Manager manager) {
-        super(manager);
+    public EditTextCommandFactory(ElementIdManager elementIdManager,
+                                  Manager manager, ExecutedCommandList executedCommandList) {
+        super(manager, executedCommandList);
         this.elementIdManager = elementIdManager;
     }
 

--- a/src/main/java/carleton/sysc4907/command/MoveCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/MoveCommandFactory.java
@@ -3,14 +3,16 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 
 public class MoveCommandFactory extends TrackedCommandFactory<Command<MoveCommandArgs>, MoveCommandArgs> {
 
     private final ElementIdManager elementIdManager;
 
-    public MoveCommandFactory(ElementIdManager elementIdManager, Manager manager) {
-        super(manager);
+    public MoveCommandFactory(ElementIdManager elementIdManager,
+                              Manager manager, ExecutedCommandList executedCommandList) {
+        super(manager, executedCommandList);
         this.elementIdManager = elementIdManager;
     }
 

--- a/src/main/java/carleton/sysc4907/command/RemoteCommand.java
+++ b/src/main/java/carleton/sysc4907/command/RemoteCommand.java
@@ -1,0 +1,37 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.communications.Message;
+import carleton.sysc4907.communications.MessageType;
+import carleton.sysc4907.communications.TargetedMessage;
+import carleton.sysc4907.model.ExecutedCommandList;
+import javafx.application.Platform;
+
+import java.time.LocalTime;
+
+public class RemoteCommand<TArgs> implements Command<TArgs> {
+
+    private final Command<TArgs> command;
+    private final ExecutedCommandList executedCommandList;
+
+    /**
+     * Creates a new tracked command to wrap another command.
+     * @param command the command to wrap.
+     */
+    public RemoteCommand(Command<TArgs> command, ExecutedCommandList executedCommandList) {
+        this.command = command;
+        this.executedCommandList = executedCommandList;
+    }
+
+    public TArgs getArgs() {
+        return command.getArgs();
+    }
+
+    @Override
+    public void execute() {
+        // Add the command to the running queue
+        Platform.runLater(command::execute);
+        executedCommandList.getCommandList().add(command); // When a command is received (including back to client) add it
+        System.out.println("Remote command finished executing (on platform) at time " + LocalTime.now());
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/RemoveCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/RemoveCommandFactory.java
@@ -4,14 +4,16 @@ import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 
 public class RemoveCommandFactory extends TrackedCommandFactory<Command<RemoveCommandArgs>, RemoveCommandArgs> {
     private final DiagramModel diagramModel;
     private final ElementIdManager elementIdManager;
 
-    public RemoveCommandFactory(DiagramModel diagramModel, ElementIdManager elementIdManager, Manager manager) {
-        super(manager);
+    public RemoveCommandFactory(DiagramModel diagramModel, ElementIdManager elementIdManager,
+                                Manager manager, ExecutedCommandList executedCommandList) {
+        super(manager, executedCommandList);
         this.diagramModel = diagramModel;
         this.elementIdManager = elementIdManager;
     }

--- a/src/main/java/carleton/sysc4907/command/ResizeCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/ResizeCommandFactory.java
@@ -2,14 +2,16 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.ResizeCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 
 public class ResizeCommandFactory extends TrackedCommandFactory<Command<ResizeCommandArgs>, ResizeCommandArgs> {
 
     private final ElementIdManager elementIdManager;
 
-    public ResizeCommandFactory(ElementIdManager elementIdManager, Manager manager) {
-        super(manager);
+    public ResizeCommandFactory(ElementIdManager elementIdManager,
+                                Manager manager, ExecutedCommandList executedCommandList) {
+        super(manager, executedCommandList);
         this.elementIdManager = elementIdManager;
     }
     @Override

--- a/src/main/java/carleton/sysc4907/command/TrackedCommand.java
+++ b/src/main/java/carleton/sysc4907/command/TrackedCommand.java
@@ -4,6 +4,7 @@ import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.communications.Message;
 import carleton.sysc4907.communications.MessageType;
 import carleton.sysc4907.communications.TargetedMessage;
+import carleton.sysc4907.model.ExecutedCommandList;
 import javafx.application.Platform;
 
 import java.time.LocalTime;
@@ -17,15 +18,17 @@ public class TrackedCommand<TArgs> implements Command<TArgs>{
 
     private final Command<TArgs> command;
     private final Manager manager;
+    private final ExecutedCommandList executedCommandList;
 
     /**
      * Creates a new tracked command to wrap another command.
      * @param command the command to wrap.
      * @param manager the manager instance.
      */
-    public TrackedCommand(Command<TArgs> command, Manager manager) {
+    public TrackedCommand(Command<TArgs> command, Manager manager, ExecutedCommandList executedCommandList) {
         this.command = command;
         this.manager = manager;
+        this.executedCommandList = executedCommandList;
     }
 
     public TArgs getArgs() {
@@ -38,6 +41,7 @@ public class TrackedCommand<TArgs> implements Command<TArgs>{
         // Tracked commands must be sent to the host first, they will be run untracked by the client
         if (manager.isHost()) {
             Platform.runLater(command::execute);
+            executedCommandList.getCommandList().add(command); // The host does not receive its command back so add it here
             System.out.println("Tracked command finished executing (on platform) at time " + LocalTime.now());
         }
 

--- a/src/main/java/carleton/sysc4907/command/TrackedCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/TrackedCommandFactory.java
@@ -1,6 +1,7 @@
 package carleton.sysc4907.command;
 
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 
 /**
  * A factory to instantiate tracked commands.
@@ -10,11 +11,18 @@ import carleton.sysc4907.communications.Manager;
 public abstract class TrackedCommandFactory<T extends Command<TArgs>, TArgs> implements CommandFactory<T, TArgs>{
 
     private final Manager manager;
-    public TrackedCommandFactory(Manager manager) {
+    private final ExecutedCommandList executedCommandList;
+    public TrackedCommandFactory(Manager manager, ExecutedCommandList executedCommandList) {
         this.manager = manager;
+        this.executedCommandList = executedCommandList;
     }
     @Override
     public Command<TArgs> createTracked(TArgs args) {
-        return new TrackedCommand<>(create(args), manager);
+        return new TrackedCommand<>(create(args), manager, executedCommandList);
+    }
+
+    @Override
+    public Command<TArgs> createRemote(TArgs args) {
+        return new RemoteCommand<>(create(args), executedCommandList);
     }
 }

--- a/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
+++ b/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
@@ -113,7 +113,7 @@ public class MessageInterpreter {
         if (factory == null) {
             throw new IllegalArgumentException("The given message did not correspond to a known type of command arguments.");
         }
-        Command<?> command = factory.create(argType.cast(args));
+        Command<?> command = factory.createRemote(argType.cast(args));
 
         Platform.runLater(command::execute);
         System.out.println("Interpreted command finished executing (on platform) at time " + LocalTime.now());

--- a/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
+++ b/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
@@ -1,8 +1,10 @@
 package carleton.sysc4907.controller;
 
+import carleton.sysc4907.command.Command;
 import carleton.sysc4907.command.MoveCommandFactory;
 import carleton.sysc4907.command.RemoveCommandFactory;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.fxml.FXML;
@@ -12,6 +14,7 @@ import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Controller for the main menu bar of the diagram editor, which includes File/Edit options, etc.
@@ -27,14 +30,16 @@ public class DiagramMenuBarController {
     private final DiagramModel diagramModel;
 
     private final RemoveCommandFactory removeCommandFactory;
+    private final ExecutedCommandList executedCommandList;
 
     /**
      * Constructs a new DiagramMenuBarController.
      * @param diagramModel the DiagramModel for the current diagram.
      */
-    public DiagramMenuBarController(DiagramModel diagramModel, RemoveCommandFactory removeCommandFactory) {
+    public DiagramMenuBarController(DiagramModel diagramModel, RemoveCommandFactory removeCommandFactory, ExecutedCommandList executedCommandList) {
         this.diagramModel = diagramModel;
         this.removeCommandFactory = removeCommandFactory;
+        this.executedCommandList = executedCommandList;
     }
 
     /**
@@ -55,7 +60,15 @@ public class DiagramMenuBarController {
             var command = removeCommandFactory.createTracked(args);
             command.execute();
         }
+    }
 
+    /**
+     * Saves the diagram.
+     */
+    public void saveDiagram() {
+        var commandList = executedCommandList.getCommandList();
+        commandList.forEach(System.out::println);
+        System.out.println(commandList.size());
     }
 
     /**

--- a/src/main/java/carleton/sysc4907/model/ExecutedCommandList.java
+++ b/src/main/java/carleton/sysc4907/model/ExecutedCommandList.java
@@ -1,0 +1,23 @@
+package carleton.sysc4907.model;
+
+import carleton.sysc4907.command.Command;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ExecutedCommandList {
+
+    private final List<Command<?>> commands;
+
+    public ExecutedCommandList(List<Command<?>> commands) {
+        this.commands = commands;
+    }
+
+    public ExecutedCommandList() {
+        this(new LinkedList<>());
+    }
+
+    public List<Command<?>> getCommandList() {
+        return commands;
+    }
+}

--- a/src/main/resources/carleton/sysc4907/view/DiagramMenu.fxml
+++ b/src/main/resources/carleton/sysc4907/view/DiagramMenu.fxml
@@ -13,7 +13,7 @@
     <Menu text="File">
         <MenuItem text="New" disable="true"/>
         <MenuItem text="Open" disable="true"/>
-        <MenuItem text="Save" disable="true"/>
+        <MenuItem text="Save" onAction="#saveDiagram"/>
         <MenuItem text="Save As" disable="true"/>
         <SeparatorMenuItem/>
         <MenuItem text="Export To Image" disable="true"/>

--- a/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
@@ -4,6 +4,7 @@ import carleton.sysc4907.command.args.AddCommandArgs;
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementCreator;
 import javafx.scene.Node;
 import org.junit.jupiter.api.Test;
@@ -17,9 +18,10 @@ public class AddCommandFactoryTest {
         String fxmlPath = "TestPath";
         DiagramModel diagramModel = new DiagramModel();
         ElementCreator mockElementCreator = Mockito.mock(ElementCreator.class);
+        ExecutedCommandList mockExecutedCommandList = Mockito.mock(ExecutedCommandList.class);
         AddCommandArgs args = new AddCommandArgs(fxmlPath, 0);
         Manager mockManager = Mockito.mock(Manager.class);
-        AddCommandFactory factory = new AddCommandFactory(diagramModel, mockElementCreator, mockManager);
+        AddCommandFactory factory = new AddCommandFactory(diagramModel, mockElementCreator, mockManager, mockExecutedCommandList);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/ConnectorMovePointFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ConnectorMovePointFactoryTest.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import javafx.collections.ObservableMap;
 import org.junit.jupiter.api.Test;
@@ -18,12 +19,15 @@ public class ConnectorMovePointFactoryTest {
     @Mock
     private ElementIdManager mockElementIdManager;
 
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
+
     @Test
     void createCommand() {
         long testId = 12L;
         Manager mockManager = Mockito.mock(Manager.class);
         var args = new ConnectorMovePointCommandArgs(false, 20, -30, testId);
-        var factory = new ConnectorMovePointCommandFactory(mockElementIdManager, mockManager);
+        var factory = new ConnectorMovePointCommandFactory(mockElementIdManager, mockManager, mockExecutedCommandList);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/EditTextCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/EditTextCommandFactoryTest.java
@@ -3,6 +3,7 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.EditTextCommandArgs;
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +18,8 @@ public class EditTextCommandFactoryTest {
 
     @Mock
     private ElementIdManager mockElementIdManager;
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
 
     @Test
     void createCommand() {
@@ -24,7 +27,7 @@ public class EditTextCommandFactoryTest {
         String testString = "Test";
         Manager mockManager = Mockito.mock(Manager.class);
         var args = new EditTextCommandArgs(testString, testId);
-        EditTextCommandFactory factory = new EditTextCommandFactory(mockElementIdManager, mockManager);
+        EditTextCommandFactory factory = new EditTextCommandFactory(mockElementIdManager, mockManager, mockExecutedCommandList);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/MoveCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/MoveCommandFactoryTest.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import javafx.scene.Node;
 import org.junit.jupiter.api.Test;
@@ -19,13 +20,15 @@ public class MoveCommandFactoryTest {
     private Node mockNode;
     @Mock
     private ElementIdManager mockElementIdManager;
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
 
     @Test
     void createCommand() {
         long testId = 12L;
         MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, testId);
         Manager mockManager = Mockito.mock(Manager.class);
-        MoveCommandFactory factory = new MoveCommandFactory(mockElementIdManager, mockManager);
+        MoveCommandFactory factory = new MoveCommandFactory(mockElementIdManager, mockManager, mockExecutedCommandList);
 
         var command = factory.create(args);
 
@@ -37,7 +40,7 @@ public class MoveCommandFactoryTest {
         long testId = 12L;
         MoveCommandArgs args = new MoveCommandArgs(10, 0, 40, -30, testId);
         Manager mockManager = Mockito.mock(Manager.class);
-        MoveCommandFactory factory = new MoveCommandFactory(mockElementIdManager, mockManager);
+        MoveCommandFactory factory = new MoveCommandFactory(mockElementIdManager, mockManager, mockExecutedCommandList);
 
         var command = factory.createTracked(args);
 

--- a/src/test/java/carleton/sysc4907/command/RemoveCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/RemoveCommandFactoryTest.java
@@ -3,6 +3,7 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,13 +21,15 @@ public class RemoveCommandFactoryTest {
 
     @Mock
     private ElementIdManager mockElementIdManager;
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
     @Test
     void createCommand() {
         long[] ids = new long[0];
         RemoveCommandArgs args = new RemoveCommandArgs(ids);
         DiagramModel diagramModel = new DiagramModel();
         Manager mockManager = Mockito.mock(Manager.class);
-        RemoveCommandFactory factory = new RemoveCommandFactory(diagramModel, mockElementIdManager, mockManager);
+        RemoveCommandFactory factory = new RemoveCommandFactory(diagramModel, mockElementIdManager, mockManager, mockExecutedCommandList);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ResizeCommandFactoryTest.java
@@ -3,6 +3,7 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.command.args.ResizeCommandArgs;
 import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
@@ -21,6 +22,8 @@ public class ResizeCommandFactoryTest {
     private Node mockNode;
     @Mock
     private ElementIdManager mockElementIdManager;
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
 
     @Test
     void createCommand() {
@@ -29,7 +32,7 @@ public class ResizeCommandFactoryTest {
         ResizeCommandArgs args = new ResizeCommandArgs(true, true,
                 10, 0, 40, -30, 0, 0, 100, 200, testId);
         Manager mockManager = Mockito.mock(Manager.class);
-        ResizeCommandFactory factory = new ResizeCommandFactory(mockElementIdManager, mockManager);
+        ResizeCommandFactory factory = new ResizeCommandFactory(mockElementIdManager, mockManager, mockExecutedCommandList);
 
         var command = factory.create(args);
 

--- a/src/test/java/carleton/sysc4907/command/TrackedCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/TrackedCommandTest.java
@@ -2,6 +2,7 @@ package carleton.sysc4907.command;
 import carleton.sysc4907.command.args.MoveCommandArgs;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.communications.TargetedMessage;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import javafx.application.Platform;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,12 +23,15 @@ public class TrackedCommandTest {
     private Manager mockManager;
     @Mock
     private MoveCommand mockMoveCommand;
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
 
     @Test
     void executeTrackedCommand() {
         //setup
-        Command<MoveCommandArgs> trackedCommand = new TrackedCommand<>(mockMoveCommand, mockManager);
+        Command<MoveCommandArgs> trackedCommand = new TrackedCommand<>(mockMoveCommand, mockManager, mockExecutedCommandList);
         Mockito.when(mockManager.isHost()).thenReturn(true);
+        Mockito.when(mockExecutedCommandList.getCommandList()).thenReturn(new LinkedList<>());
 
         try (MockedStatic<Platform> platformMockedStatic = Mockito.mockStatic(Platform.class)) {
             // test
@@ -33,6 +39,7 @@ public class TrackedCommandTest {
 
             // verify
             Mockito.verify(mockManager).send(any(TargetedMessage.class));
+            Mockito.verify(mockExecutedCommandList).getCommandList();
             platformMockedStatic.verify(() -> Platform.runLater(any()));
         }
     }
@@ -40,7 +47,7 @@ public class TrackedCommandTest {
     @Test
     void executeTrackedCommandClient() {
         //setup
-        Command<MoveCommandArgs> trackedCommand = new TrackedCommand<>(mockMoveCommand, mockManager);
+        Command<MoveCommandArgs> trackedCommand = new TrackedCommand<>(mockMoveCommand, mockManager, mockExecutedCommandList);
         Mockito.when(mockManager.isHost()).thenReturn(false);
 
         try (MockedStatic<Platform> platformMockedStatic = Mockito.mockStatic(Platform.class)) {

--- a/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
+++ b/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
@@ -41,7 +41,7 @@ public class MessageInterpreterTest {
     public void interpretUpdateMoveCommandHost() {
         // setup
         var args = new MoveCommandArgs(0, 0, 1, 1, 0L);
-        Mockito.when(moveCommandFactory.create(any(MoveCommandArgs.class))).thenReturn(mockCommand);
+        Mockito.when(moveCommandFactory.createRemote(any(MoveCommandArgs.class))).thenReturn(mockCommand);
         Mockito.doNothing().when(messageConstructor).send(any(Message.class));
         Mockito.when(manager.isHost()).thenReturn(true);
         MessageInterpreter interpreter = new MessageInterpreter(
@@ -61,7 +61,7 @@ public class MessageInterpreterTest {
             interpreter.interpret(new Message(MessageType.UPDATE, args), 0);
 
             // verify
-            Mockito.verify(moveCommandFactory).create(any(MoveCommandArgs.class));
+            Mockito.verify(moveCommandFactory).createRemote(any(MoveCommandArgs.class));
             Mockito.verify(messageConstructor).send(any(Message.class));
             platformMockedStatic.verify(() -> Platform.runLater(any()));
         }
@@ -71,7 +71,7 @@ public class MessageInterpreterTest {
     public void interpretUpdateMoveCommandClient() {
         // setup
         var args = new MoveCommandArgs(0, 0, 1, 1, 0L);
-        Mockito.when(moveCommandFactory.create(any(MoveCommandArgs.class))).thenReturn(mockCommand);
+        Mockito.when(moveCommandFactory.createRemote(any(MoveCommandArgs.class))).thenReturn(mockCommand);
         Mockito.when(manager.isHost()).thenReturn(false);
         MessageInterpreter interpreter = new MessageInterpreter(
                 addCommandFactory,
@@ -90,7 +90,7 @@ public class MessageInterpreterTest {
             interpreter.interpret(new Message(MessageType.UPDATE, args), 0);
 
             // verify
-            Mockito.verify(moveCommandFactory).create(any(MoveCommandArgs.class));
+            Mockito.verify(moveCommandFactory).createRemote(any(MoveCommandArgs.class));
             Mockito.verify(messageConstructor, Mockito.never()).send(any(Message.class));
             platformMockedStatic.verify(() -> Platform.runLater(any()));
         }

--- a/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
@@ -28,7 +28,7 @@ public class ConnectorTest extends DiagramElementTest {
     @Override
     protected void start(Stage stage) throws IOException {
         connectorHandleCreator = new ConnectorHandleCreator();
-        connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(elementIdManager, mockManager);
+        connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(elementIdManager, mockManager, mockExecutedCommandList);
         super.start(stage);
         controller = (ConnectorElementController) element.getProperties().get("controller");
     }

--- a/src/test/java/carleton/sysc4907/ui/view/DiagramElementTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/DiagramElementTest.java
@@ -7,6 +7,7 @@ import carleton.sysc4907.controller.DiagramEditingAreaController;
 import carleton.sysc4907.controller.element.MovePreviewCreator;
 import carleton.sysc4907.model.DiagramModel;
 import carleton.sysc4907.controller.element.RectangleController;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.TextFormattingModel;
@@ -64,6 +65,8 @@ public abstract class DiagramElementTest {
 
     @Mock
     protected ElementIdManager elementIdManager;
+    @Mock
+    protected ExecutedCommandList mockExecutedCommandList;
 
     /**
      * Sets up the scene before each test, loading an editing area and adding the element inside it.
@@ -73,7 +76,7 @@ public abstract class DiagramElementTest {
     @Start
     protected void start(Stage stage) throws IOException {
         diagramModel = new DiagramModel();
-        moveCommandFactory = new MoveCommandFactory(elementIdManager, mockManager);
+        moveCommandFactory = new MoveCommandFactory(elementIdManager, mockManager, mockExecutedCommandList);
         initializeDependencyInjector();
         // Load the scroll pane and get the editing area from it
         ScrollPane root = (ScrollPane) dependencyInjector.load("view/DiagramEditingArea.fxml");

--- a/src/test/java/carleton/sysc4907/ui/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ElementLibraryPanelTest.java
@@ -6,6 +6,7 @@ import carleton.sysc4907.command.AddCommandFactory;
 import carleton.sysc4907.communications.Manager;
 import carleton.sysc4907.controller.ElementLibraryPanelController;
 import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
@@ -27,6 +28,7 @@ import org.testfx.framework.junit5.Start;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedList;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -53,6 +55,9 @@ public class ElementLibraryPanelTest {
     private ElementCreator mockElementCreator;
 
     @Mock
+    private ExecutedCommandList mockExecutedCommandList;
+
+    @Mock
     private DiagramElement mockDiagramElement;
 
     @Mock
@@ -69,7 +74,7 @@ public class ElementLibraryPanelTest {
             DependencyInjector injector = new DependencyInjector();
 
             Manager mockManager = Mockito.mock(Manager.class);
-            AddCommandFactory addCommandFactory = new AddCommandFactory(mockDiagramModel, mockElementCreator, mockManager);
+            AddCommandFactory addCommandFactory = new AddCommandFactory(mockDiagramModel, mockElementCreator, mockManager, mockExecutedCommandList);
             injector.addInjectionMethod(ElementLibraryPanelController.class,
                     () -> {
                         var controller = new ElementLibraryPanelController(
@@ -97,6 +102,7 @@ public class ElementLibraryPanelTest {
         Mockito.when(mockNodesList.add(any(Node.class))).thenReturn(true);
         Mockito.when(mockElementCreator.create("rectangleType", testId, true))
                 .thenReturn(mockDiagramElement);
+        Mockito.when(mockExecutedCommandList.getCommandList()).thenReturn(new LinkedList<>());
         Mockito.when(mockElementIdManager.getNewIdRange(anyInt())).thenReturn(testId);
 
         robot.clickOn("#elementsPane .button");

--- a/src/test/java/carleton/sysc4907/ui/view/ResizableElementTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ResizableElementTest.java
@@ -32,7 +32,7 @@ public abstract class ResizableElementTest extends DiagramElementTest {
     protected void start(Stage stage) throws IOException {
         resizeHandleCreator = new ResizeHandleCreator();
         Manager mockManager = Mockito.mock(Manager.class);
-        resizeCommandFactory = new ResizeCommandFactory(elementIdManager, mockManager);
+        resizeCommandFactory = new ResizeCommandFactory(elementIdManager, mockManager, mockExecutedCommandList);
         super.start(stage);
     }
 

--- a/src/test/java/carleton/sysc4907/ui/view/UmlClassTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/UmlClassTest.java
@@ -39,7 +39,7 @@ public class UmlClassTest extends ResizableElementTest {
                         resizePreviewCreator,
                         resizeCommandFactory));
         dependencyInjector.addInjectionMethod(EditableLabelController.class,
-                () -> new EditableLabelController(new EditTextCommandFactory(elementIdManager, mockManager)));
+                () -> new EditableLabelController(new EditTextCommandFactory(elementIdManager, mockManager, mockExecutedCommandList)));
     }
 
     @Override

--- a/src/test/java/carleton/sysc4907/ui/view/UmlCommentTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/UmlCommentTest.java
@@ -38,7 +38,7 @@ public class UmlCommentTest extends ResizableElementTest {
                         resizePreviewCreator,
                         resizeCommandFactory));
         dependencyInjector.addInjectionMethod(EditableLabelController.class,
-                () -> new EditableLabelController(new EditTextCommandFactory(elementIdManager, mockManager)));
+                () -> new EditableLabelController(new EditTextCommandFactory(elementIdManager, mockManager, mockExecutedCommandList)));
     }
 
     @Override


### PR DESCRIPTION
First step to implement a save/load system based on commands.

An ExecutedCommandList wrapping a list is used to track all run commands that aren't preview-related, both run by this user and others.

A new "remote" command type is added, wrapping commands similar to tracked commands. Remote commands are always added to the executed command list. Tracked commands are added to the executed command list **only on the host**: clients will receive the command bounced back to them as a remote command and add it then.

The "Save" button in the menu has been enabled and prints debug info about the current executed command list, showing each element printed + the total count.

Needs multi-person testing to make sure the remote commands are correctly added to both hosts' and clients' executed command lists.