### PR TITLE
Connector move point previews

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -136,6 +136,9 @@ public class DiagramEditorLoader {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        ConnectorMovePointPreviewCreator connectorMovePointPreviewCreator = new ConnectorMovePointPreviewCreator(
+                elementIdManager, elementCreator
+        );
 
         MoveCommandFactory moveCommandFactory = new MoveCommandFactory(
                 elementIdManager, manager, executedCommandList);
@@ -185,6 +188,7 @@ public class DiagramEditorLoader {
                         moveCommandFactory,
                         diagramModel,
                         connectorHandleCreator,
+                        connectorMovePointPreviewCreator,
                         connectorMovePointCommandFactory,
                         new CurvedPathStrategy()));
 

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorMovePointPreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorMovePointPreviewCreator.java
@@ -33,7 +33,7 @@ public class ConnectorMovePointPreviewCreator {
         previewController.setSnapEnd(controller.getSnapEnd());
 
         Pane editingArea = EditingAreaProvider.getEditingArea();
-        editingArea.getChildren().add(previewController.element);
+        editingArea.getChildren().add(element);
 
         return previewController;
     }

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorMovePointPreviewCreator.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorMovePointPreviewCreator.java
@@ -1,0 +1,47 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.processing.ElementIdManager;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.scene.layout.Pane;
+
+public class ConnectorMovePointPreviewCreator {
+
+    private final ElementIdManager elementIdManager;
+
+    private final ElementCreator elementCreator;
+
+    public ConnectorMovePointPreviewCreator(ElementIdManager elementIdManager, ElementCreator elementCreator) {
+        this.elementIdManager = elementIdManager;
+        this.elementCreator = elementCreator;
+    }
+
+    public ConnectorElementController createMovePointPreview(ConnectorElementController controller) {
+        // Create a new connector element and get its controller
+        var element = elementCreator.create("Line", elementIdManager.getNewId(), true);
+        var previewController = (ConnectorElementController) element.getProperties().get("controller");
+        element.setOpacity(0.3);
+        previewController.setPathingStrategy(controller.getPathingStrategy());
+        previewController.setStartX(controller.getStartX());
+        previewController.setEndX(controller.getEndX());
+        previewController.setStartY(controller.getStartY());
+        previewController.setEndY(controller.getEndY());
+        previewController.setIsStartHorizontal(controller.getIsStartHorizontal());
+        previewController.setIsEndHorizontal(controller.getIsEndHorizontal());
+        previewController.setSnapStart(controller.getSnapStart());
+        previewController.setSnapEnd(controller.getSnapEnd());
+
+        Pane editingArea = EditingAreaProvider.getEditingArea();
+        editingArea.getChildren().add(previewController.element);
+
+        return previewController;
+    }
+
+    public void deleteMovePreview(DiagramElement element, ConnectorElementController connectorElementController) {
+        if (connectorElementController == null) {
+            return;
+        }
+        ((Pane) element.getParent()).getChildren().remove(connectorElementController.element);
+    }
+}

--- a/src/test/java/carleton/sysc4907/controller/element/ConnectorElementControllerTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/ConnectorElementControllerTest.java
@@ -25,6 +25,9 @@ public class ConnectorElementControllerTest {
     private DiagramModel diagramModel;
     @Mock
     private ConnectorHandleCreator connectorHandleCreator;
+
+    @Mock
+    private ConnectorMovePointPreviewCreator connectorMovePointPreviewCreator;
     @Mock
     private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
     @Mock
@@ -41,6 +44,7 @@ public class ConnectorElementControllerTest {
                 moveCommandFactory,
                 diagramModel,
                 connectorHandleCreator,
+                connectorMovePointPreviewCreator,
                 connectorMovePointCommandFactory,
                 pathingStrategy
         );
@@ -70,6 +74,7 @@ public class ConnectorElementControllerTest {
                 moveCommandFactory,
                 diagramModel,
                 connectorHandleCreator,
+                connectorMovePointPreviewCreator,
                 connectorMovePointCommandFactory,
                 pathingStrategy
         );
@@ -97,6 +102,7 @@ public class ConnectorElementControllerTest {
                 moveCommandFactory,
                 diagramModel,
                 connectorHandleCreator,
+                connectorMovePointPreviewCreator,
                 connectorMovePointCommandFactory,
                 pathingStrategy
         );
@@ -123,6 +129,7 @@ public class ConnectorElementControllerTest {
                 moveCommandFactory,
                 diagramModel,
                 connectorHandleCreator,
+                connectorMovePointPreviewCreator,
                 connectorMovePointCommandFactory,
                 pathingStrategy
         );
@@ -152,6 +159,7 @@ public class ConnectorElementControllerTest {
                 moveCommandFactory,
                 diagramModel,
                 connectorHandleCreator,
+                connectorMovePointPreviewCreator,
                 connectorMovePointCommandFactory,
                 pathingStrategy
         );

--- a/src/test/java/carleton/sysc4907/controller/element/ConnectorMovePointPreviewCreatorTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/ConnectorMovePointPreviewCreatorTest.java
@@ -1,0 +1,92 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.controller.element.pathing.PathingStrategy;
+import carleton.sysc4907.processing.ElementCreator;
+import carleton.sysc4907.processing.ElementIdManager;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectorMovePointPreviewCreatorTest {
+
+    @Mock
+    private ElementIdManager elementIdManager;
+
+    @Mock
+    private ElementCreator elementCreator;
+
+    @Mock
+    private ConnectorElementController connectorElementController;
+
+    @Mock
+    private DiagramElement createdPreview;
+    @Mock
+    private ObservableMap<Object, Object> createdPreviewProperties;
+    @Mock
+    private ConnectorElementController createdPreviewController;
+    @Mock
+    private PathingStrategy pathingStrategy;
+    @Mock
+    private Pane mockEditingArea;
+
+    @Mock
+    private ObservableList<Node> mockNodesList;
+
+    @Test
+    public void testPreviewCreatedFromController() {
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+            ConnectorMovePointPreviewCreator connectorMovePointPreviewCreator = new ConnectorMovePointPreviewCreator(
+                    elementIdManager,
+                    elementCreator
+            );
+
+            when(elementCreator.create(eq("Line"), anyLong(), eq(true))).thenReturn(
+                    createdPreview
+            );
+            when(createdPreview.getProperties()).thenReturn(createdPreviewProperties);
+            when(createdPreviewProperties.get("controller")).thenReturn(createdPreviewController);
+            when(elementIdManager.getNewId()).thenReturn(0L);
+            // Mock getters for previous controller
+            when(connectorElementController.getPathingStrategy()).thenReturn(pathingStrategy);
+            when(connectorElementController.getStartX()).thenReturn(10.0);
+            when(connectorElementController.getStartY()).thenReturn(20.0);
+            when(connectorElementController.getEndX()).thenReturn(30.0);
+            when(connectorElementController.getEndY()).thenReturn(40.0);
+            when(connectorElementController.getIsStartHorizontal()).thenReturn(true);
+            when(connectorElementController.getIsEndHorizontal()).thenReturn(false);
+            when(connectorElementController.getSnapStart()).thenReturn(false);
+            when(connectorElementController.getSnapEnd()).thenReturn(true);
+
+            Mockito.when(mockEditingArea.getChildren())
+                    .thenReturn(mockNodesList);
+            connectorMovePointPreviewCreator.createMovePointPreview(connectorElementController);
+
+            verify(createdPreview).setOpacity(0.3);
+            verify(createdPreviewController).setPathingStrategy(pathingStrategy);
+            verify(createdPreviewController).setStartX(10.0);
+            verify(createdPreviewController).setStartY(20.0);
+            verify(createdPreviewController).setEndX(30.0);
+            verify(createdPreviewController).setEndY(40.0);
+            verify(createdPreviewController).setIsStartHorizontal(true);
+            verify(createdPreviewController).setIsEndHorizontal(false);
+            verify(createdPreviewController).setSnapStart(false);
+            verify(createdPreviewController).setSnapEnd(true);
+            verify(mockNodesList).add(createdPreview);
+        }
+    }
+}

--- a/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ConnectorTest.java
@@ -3,17 +3,18 @@ package carleton.sysc4907.ui.view;
 import carleton.sysc4907.command.ConnectorMovePointCommandFactory;
 import carleton.sysc4907.controller.element.ConnectorElementController;
 import carleton.sysc4907.controller.element.ConnectorHandleCreator;
+import carleton.sysc4907.controller.element.ConnectorMovePointPreviewCreator;
 import carleton.sysc4907.controller.element.pathing.OrthogonalPathStrategy;
 import carleton.sysc4907.view.DiagramElement;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.Start;
 
 import java.io.IOException;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,6 +23,9 @@ public class ConnectorTest extends DiagramElementTest {
 
     private ConnectorElementController controller;
     private ConnectorHandleCreator connectorHandleCreator;
+
+    @Mock
+    private ConnectorMovePointPreviewCreator mockConnectorMovePointPreviewCreator;
     private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
 
     @Start
@@ -43,6 +47,7 @@ public class ConnectorTest extends DiagramElementTest {
                         moveCommandFactory,
                         diagramModel,
                         connectorHandleCreator,
+                        mockConnectorMovePointPreviewCreator,
                         connectorMovePointCommandFactory,
                         new OrthogonalPathStrategy()));
     }


### PR DESCRIPTION
Resolves #79. 

Broke some UI tests for this, might fix them eventually: this is a similar problem to the (unsolved) one that we have for the resizable element UI tests. The preview correctly appears when being moved manually, it's an automation issue.