### PR TITLE
Improve connector hitbox

### DIFF
--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -47,6 +47,9 @@ public class ConnectorElementController extends DiagramElementController {
     @FXML
     private Path connectorPath;
 
+    @FXML
+    private Path pathHitbox;
+
     private PathingStrategy pathingStrategy;
 
     private boolean movePointDragging = false;
@@ -90,6 +93,8 @@ public class ConnectorElementController extends DiagramElementController {
     @Override
     public void initialize() {
         super.initialize();
+        element.removeEventHandler(MouseEvent.ANY, mouseEventHandler);
+        pathHitbox.addEventHandler(MouseEvent.ANY, mouseEventHandler);
         ChangeListener<Number> listener = (observableValue, number, t1) -> {
             reposition();
             recalculatePath();
@@ -173,6 +178,11 @@ public class ConnectorElementController extends DiagramElementController {
     private void recalculatePath() {
         pathingStrategy.makePath(
                 connectorPath,
+                adjustX(getStartX()), adjustY(getStartY()), isStartHorizontal.get(),
+                adjustX(getEndX()), adjustY(getEndY()), isEndHorizontal.get()
+        );
+        pathingStrategy.makePath(
+                pathHitbox,
                 adjustX(getStartX()), adjustY(getStartY()), isStartHorizontal.get(),
                 adjustX(getEndX()), adjustY(getEndY()), isEndHorizontal.get()
         );

--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -40,6 +40,8 @@ public abstract class DiagramElementController {
 
     protected final DiagramModel diagramModel;
 
+    protected EventHandler<MouseEvent> mouseEventHandler;
+
     /**
      * Constructs a new DiagramElementController.
      *
@@ -68,13 +70,14 @@ public abstract class DiagramElementController {
     @FXML
     public void initialize() {
         // Adds registered mouse handlers to the element.
-        element.addEventHandler(MouseEvent.ANY, mouseEvent -> {
+        mouseEventHandler = mouseEvent -> {
             List<EventHandler<MouseEvent>> existingHandlers = mouseHandlers.get(mouseEvent.getEventType());
             if (existingHandlers != null) {
                 existingHandlers.forEach(handler -> handler.handle(mouseEvent));
             }
             mouseEvent.consume(); // Make it so only one element receives the event
-        });
+        };
+        element.addEventHandler(MouseEvent.ANY, mouseEventHandler);
         diagramModel.getSelectedElements().addListener((ListChangeListener<DiagramElement>) change -> {
             while (change.next()) {
                 if (change.wasAdded() && change.getAddedSubList().contains(element)) {

--- a/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
+++ b/src/main/resources/carleton/sysc4907/view/element/Connector.fxml
@@ -17,4 +17,6 @@
     </properties>
     <Path fx:id="connectorPath">
     </Path>
+    <Path fx:id="pathHitbox" styleClass="connector-path-hitbox">
+    </Path>
 </DiagramElement>

--- a/src/main/resources/stylesheet/DiagramElementsStyle.css
+++ b/src/main/resources/stylesheet/DiagramElementsStyle.css
@@ -76,6 +76,11 @@
     -fx-border-style: dashed;
 }
 
+.connector-path-hitbox {
+    -fx-stroke-width: 20;
+    -fx-stroke: #00000000;
+}
+
 .debug {
     -fx-fill: #00000000;
     -fx-stroke: red;


### PR DESCRIPTION
Currently connector hitboxes are a giant rectangle around the connector. This change makes it so the hitbox is a wide path around the actual connector path instead.