### PR TITLE
Changes so that text styles save correctly

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -19,6 +19,7 @@ import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.processing.FileSaver;
 import carleton.sysc4907.processing.FontOptionsFinder;
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
@@ -236,13 +237,15 @@ public class DiagramEditorLoader {
             MoveCommandFactory moveCommandFactory,
             ResizeCommandFactory resizeCommandFactory,
             EditTextCommandFactory editTextCommandFactory,
-            ConnectorMovePointCommandFactory connectorMovePointCommandFactory, ChangeTextStyleCommandFactory changeTextStyleCommandFactory) {
+            ConnectorMovePointCommandFactory connectorMovePointCommandFactory,
+            ChangeTextStyleCommandFactory changeTextStyleCommandFactory) {
         commandFactories.put(AddCommandArgs.class, addCommandFactory);
         commandFactories.put(RemoveCommandArgs.class, removeCommandFactory);
         commandFactories.put(MoveCommandArgs.class, moveCommandFactory);
         commandFactories.put(ResizeCommandArgs.class, resizeCommandFactory);
         commandFactories.put(EditTextCommandArgs.class, editTextCommandFactory);
         commandFactories.put(ConnectorMovePointCommandArgs.class, connectorMovePointCommandFactory);
+        commandFactories.put(ChangeTextStyleCommandArgs.class, changeTextStyleCommandFactory);
     }
 
     /**
@@ -258,7 +261,7 @@ public class DiagramEditorLoader {
             }
             // Use remote commands to add them to the command list without transmitting them elsewhere
             Command<?> command = factory.createRemote((CommandArgs) argType.cast(args));
-            command.execute();
+            Platform.runLater(command::execute);
         }
     }
 

--- a/src/main/java/carleton/sysc4907/command/ChangeTextStyleCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ChangeTextStyleCommand.java
@@ -13,6 +13,8 @@ import org.w3c.dom.Text;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A command to change the styling of the text in a label.
@@ -84,6 +86,12 @@ public class ChangeTextStyleCommand implements Command<ChangeTextStyleCommandArg
             case SIZE -> {
                 System.out.println("size");
                 String fontFamily = label.getFont().getFamily();
+                Pattern pattern = Pattern.compile("-fx-font-family:\\s*\"(.+)\"\\s*;");
+                var matcher = pattern.matcher(label.getStyle());
+                if (matcher.find()) {
+                    fontFamily = matcher.group(1);
+                    System.out.println("fontFamily found from style: " + fontFamily);
+                }
                 textField.setStyle("-fx-font-family: \"" + fontFamily + "\"; -fx-font-size: " + valueToApply + ";");
                 label.setStyle("-fx-font-family: \"" + fontFamily + "\"; -fx-font-size: " + valueToApply + ";");
                 break;
@@ -125,6 +133,16 @@ public class ChangeTextStyleCommand implements Command<ChangeTextStyleCommandArg
             case FONT_FAMILY -> {
                 System.out.println("font-family");
                 double oldFontSize = label.getFont().getSize();
+                Pattern pattern = Pattern.compile("-fx-font-size:\\s*(\\d+)");
+                var matcher = pattern.matcher(label.getStyle());
+                if (matcher.find()) {
+                    try {
+                        oldFontSize = Double.parseDouble(matcher.group(1));
+                        System.out.println("fontSize found from style: " + oldFontSize);
+                    } catch (NumberFormatException e) {
+                        System.out.println("Invalid number in style, using value found from font " + oldFontSize);
+                    }
+                }
                 textField.setStyle("-fx-font-family: \"" + valueToApply + "\"; -fx-font-size: " + oldFontSize + ";");
                 label.setStyle("-fx-font-family: \"" + valueToApply + "\"; -fx-font-size: " + oldFontSize + ";");
                 break;

--- a/src/main/java/carleton/sysc4907/command/CommandListCompressor.java
+++ b/src/main/java/carleton/sysc4907/command/CommandListCompressor.java
@@ -50,7 +50,7 @@ public class CommandListCompressor {
                 )).toList();
     }
 
-    private Command<?> findLastOfType(List<Command<?>> commandList, Class type) {
+    private Command<?> findLastCommandOfType(List<Command<?>> commandList, Class type) {
         var commandsOfType = commandList.stream().filter(cmd ->  type.isInstance(cmd.getArgs())).toList();
         if (commandsOfType.isEmpty()) {
             return null;
@@ -59,20 +59,49 @@ public class CommandListCompressor {
         }
     }
 
-    private List<Command<?>> findLastConnectorMoves(List<Command<?>> commandList) {
+    /**
+     * Finds the last connector move point commands from the command list. One command will be returned for the start point,
+     * another for the end point.
+     * @param commandList the list of commands that have been run for a given ID
+     * @return the commands that should be saved
+     */
+    private List<Command<?>> findLastConnectorMoveCommands(List<Command<?>> commandList) {
         var movePointCommands = commandList.stream().filter(cmd ->  cmd.getArgs() instanceof ConnectorMovePointCommandArgs).toList();
-        var startMoves = movePointCommands.stream().filter(cmd -> ((ConnectorMovePointCommandArgs) (cmd.getArgs())).isStart()).toList();
-        var endMoves = movePointCommands.stream().filter(cmd -> !((ConnectorMovePointCommandArgs) (cmd.getArgs())).isStart()).toList();
+        var startMovesStream = movePointCommands.stream().filter(cmd -> ((ConnectorMovePointCommandArgs) (cmd.getArgs())).isStart());
+        var endMovesStream = movePointCommands.stream().filter(cmd -> !((ConnectorMovePointCommandArgs) (cmd.getArgs())).isStart());
         List<Command<?>> lastCommands = new LinkedList<>();
-        if (!startMoves.isEmpty()) {
-            lastCommands.add(startMoves.get(startMoves.size() - 1));
+        startMovesStream.reduce((first, second) -> second).ifPresent(lastCommands::add);
+        endMovesStream.reduce((first, second) -> second).ifPresent(lastCommands::add);
+        return lastCommands;
+    }
+
+    /**
+     * Finds the last text styling commands from the command list. One command will be returned for each
+     * text styling property that has been modified.
+     * @param commandList the list of commands that have been run for a given ID
+     * @return the commands that should be saved
+     */
+    private List<Command<?>> findLastTextStylingCommands(List<Command<?>> commandList) {
+        var textStylingCommands = commandList.stream().filter(cmd ->  cmd.getArgs() instanceof ChangeTextStyleCommandArgs).toList();
+        List<Command<?>> lastCommands = new LinkedList<>();
+
+        for (TextStyleProperty property : TextStyleProperty.values()) {
+            var propertyCommandsStream = textStylingCommands.stream().filter(
+                    cmd -> ((ChangeTextStyleCommandArgs) (cmd.getArgs())).property() == property);
+            propertyCommandsStream.reduce((first, second) -> second).ifPresent(lastCommands::add);
         }
-        if (!endMoves.isEmpty()) {
-            lastCommands.add(endMoves.get(endMoves.size() - 1));
+        for (var command : lastCommands) {
+            ChangeTextStyleCommandArgs args = (ChangeTextStyleCommandArgs) command.getArgs();
+            System.out.println(args.property() + " " + args.value());
         }
         return lastCommands;
     }
 
+    /**
+     * Finds the last command from the command list that causes the element to move.
+     * @param commandList the list of commands that have been run for a given ID
+     * @return the command that should be saved
+     */
     private Command<?> findLastMove(List<Command<?>> commandList) {
         var moveCommands = commandList.stream().filter(this::isMove).toList();
         if (moveCommands.isEmpty()) {
@@ -100,7 +129,7 @@ public class CommandListCompressor {
     private List<Command<?>> compressCommandListForId(List<Command<?>> idCommandList) {
         List<Command<?>> compressedList = new LinkedList<>();
         for (Class argsType : commandArgsClasses) {
-            var lastCommandOfType = findLastOfType(idCommandList, argsType);
+            var lastCommandOfType = findLastCommandOfType(idCommandList, argsType);
             if (lastCommandOfType != null) {
                 compressedList.add(lastCommandOfType);
             }
@@ -109,7 +138,8 @@ public class CommandListCompressor {
         if (lastMove != null) {
             compressedList.add(lastMove);
         }
-        compressedList.addAll(findLastConnectorMoves(idCommandList));
+        compressedList.addAll(findLastConnectorMoveCommands(idCommandList));
+        compressedList.addAll(findLastTextStylingCommands(idCommandList));
         return compressedList;
     }
 }

--- a/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
+++ b/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
@@ -92,13 +92,15 @@ public class MessageInterpreter {
             MoveCommandFactory moveCommandFactory,
             ResizeCommandFactory resizeCommandFactory,
             EditTextCommandFactory editTextCommandFactory,
-            ConnectorMovePointCommandFactory connectorMovePointCommandFactory, ChangeTextStyleCommandFactory changeTextStyleCommandFactory) {
+            ConnectorMovePointCommandFactory connectorMovePointCommandFactory,
+            ChangeTextStyleCommandFactory changeTextStyleCommandFactory) {
         commandFactories.put(AddCommandArgs.class, addCommandFactory);
         commandFactories.put(RemoveCommandArgs.class, removeCommandFactory);
         commandFactories.put(MoveCommandArgs.class, moveCommandFactory);
         commandFactories.put(ResizeCommandArgs.class, resizeCommandFactory);
         commandFactories.put(EditTextCommandArgs.class, editTextCommandFactory);
         commandFactories.put(ConnectorMovePointCommandArgs.class, connectorMovePointCommandFactory);
+        commandFactories.put(ChangeTextStyleCommandArgs.class, changeTextStyleCommandFactory);
     }
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/element/EditableLabelController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/EditableLabelController.java
@@ -47,6 +47,9 @@ public class EditableLabelController {
      */
     @FXML
     public void initialize() {
+        String DEFAULT_FONT_FAMILY = "Segoe UI";
+        int DEFAULT_FONT_SIZE = 14;
+
         textProperty.bind(label.textProperty());
         label.setWrapText(true);
         editableText.setFocusTraversable(false);
@@ -58,6 +61,8 @@ public class EditableLabelController {
         label.minWidthProperty().bind(widthProperty.multiply(0.8));
         label.setAlignment(Pos.CENTER);
         label.setTextAlignment(TextAlignment.CENTER);
+        label.setStyle("-fx-font-family: \"" + DEFAULT_FONT_FAMILY + "\"; -fx-font-size: " + DEFAULT_FONT_SIZE + ";");
+        editableText.setStyle("-fx-font-family: \"" + DEFAULT_FONT_FAMILY + "\"; -fx-font-size: " + DEFAULT_FONT_SIZE + ";");
         editableText.setWrapText(true);
         toggleEditable(false);
         editableText.focusedProperty().addListener(((observableValue, oldValue, newValue) -> toggleEditable(newValue)));


### PR DESCRIPTION
This is a separate branch because of the changes that were made to the command.

When multiple size/fontFamily commands were run in rapid succession, which occurs during loading, the getFont() method will not retrieve the label's most current font, as modified by previous commands. This leads to some size/fontFamily commands being overwritten by the previous font size or family, when both types of commands exist.
This is fixed by using regex to search through the element's style to find the font size/family. If none is found, we find the font size or family as previously, but since the style updates instantly (even if it may not be applied to the font yet) this supports commands being run quickly.

The rest of the changes are standard: adding the command factory where it needs to be and updating the command list compressor with new logic (and some Javadocs).
