### PR TITLE
Pane for changing arrowhead style

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -171,6 +171,8 @@ public class DiagramEditorLoader {
                 elementIdManager, manager, executedCommandList, constructor);
         ConnectorMovePointCommandFactory connectorMovePointCommandFactory = new ConnectorMovePointCommandFactory(
                 elementIdManager, manager, executedCommandList, constructor);
+        ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory = new ChangeConnectorStyleCommandFactory(
+                elementIdManager, manager, executedCommandList, constructor);
         // Add factories to message interpreter: avoids circular dependencies
         interpreter.addFactories(
                 addCommandFactory,
@@ -178,7 +180,8 @@ public class DiagramEditorLoader {
                 moveCommandFactory,
                 resizeCommandFactory,
                 editTextCommandFactory,
-                connectorMovePointCommandFactory
+                connectorMovePointCommandFactory,
+                changeConnectorStyleCommandFactory
         );
         addFactories(
                 addCommandFactory,
@@ -186,7 +189,8 @@ public class DiagramEditorLoader {
                 moveCommandFactory,
                 resizeCommandFactory,
                 editTextCommandFactory,
-                connectorMovePointCommandFactory
+                connectorMovePointCommandFactory,
+                changeConnectorStyleCommandFactory
         );
 
         // Add instantiation methods for the element injector, used to create diagram element controllers
@@ -226,6 +230,8 @@ public class DiagramEditorLoader {
                 () -> new SessionInfoBarController(sessionModel));
         injector.addInjectionMethod(FormattingPanelController.class,
                 () -> new FormattingPanelController(textFormattingModel));
+        injector.addInjectionMethod(ConnectorFormattingPanelController.class,
+                () -> new ConnectorFormattingPanelController(diagramModel, elementIdManager, changeConnectorStyleCommandFactory));
         injector.addInjectionMethod(SessionUsersMenuController.class,
                 () -> new SessionUsersMenuController(sessionModel));
         injector.addInjectionMethod(DiagramMenuBarController.class,
@@ -247,13 +253,15 @@ public class DiagramEditorLoader {
             MoveCommandFactory moveCommandFactory,
             ResizeCommandFactory resizeCommandFactory,
             EditTextCommandFactory editTextCommandFactory,
-            ConnectorMovePointCommandFactory connectorMovePointCommandFactory) {
+            ConnectorMovePointCommandFactory connectorMovePointCommandFactory,
+            ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory) {
         commandFactories.put(AddCommandArgs.class, addCommandFactory);
         commandFactories.put(RemoveCommandArgs.class, removeCommandFactory);
         commandFactories.put(MoveCommandArgs.class, moveCommandFactory);
         commandFactories.put(ResizeCommandArgs.class, resizeCommandFactory);
         commandFactories.put(EditTextCommandArgs.class, editTextCommandFactory);
         commandFactories.put(ConnectorMovePointCommandArgs.class, connectorMovePointCommandFactory);
+        commandFactories.put(ChangeConnectorStyleCommandArgs.class, changeConnectorStyleCommandFactory);
     }
 
     /**

--- a/src/main/java/carleton/sysc4907/command/ChangeConnectorStyleCommand.java
+++ b/src/main/java/carleton/sysc4907/command/ChangeConnectorStyleCommand.java
@@ -1,0 +1,34 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ChangeConnectorStyleCommandArgs;
+import carleton.sysc4907.controller.element.ArrowConnectorElementController;
+import carleton.sysc4907.processing.ElementIdManager;
+
+public class ChangeConnectorStyleCommand implements Command<ChangeConnectorStyleCommandArgs> {
+
+    private final ChangeConnectorStyleCommandArgs args;
+    private final ElementIdManager elementIdManager;
+
+    public ChangeConnectorStyleCommand(ChangeConnectorStyleCommandArgs args, ElementIdManager elementIdManager) {
+        this.args = args;
+        this.elementIdManager = elementIdManager;
+    }
+
+    /**
+     * Executes the command
+     */
+    @Override
+    public void execute() {
+        var controller = elementIdManager.getElementControllerById(args.elementId());
+        if (controller == null) return;
+        if (controller instanceof ArrowConnectorElementController arrowConnectorElementController) {
+            arrowConnectorElementController.setArrowheadType(args.type());
+            arrowConnectorElementController.setPathStyle(args.type());
+        }
+    }
+
+    @Override
+    public ChangeConnectorStyleCommandArgs getArgs() {
+        return args;
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/ChangeConnectorStyleCommandFactory.java
+++ b/src/main/java/carleton/sysc4907/command/ChangeConnectorStyleCommandFactory.java
@@ -1,0 +1,31 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ChangeConnectorStyleCommandArgs;
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.communications.MessageConstructor;
+import carleton.sysc4907.model.ExecutedCommandList;
+import carleton.sysc4907.processing.ElementIdManager;
+
+public class ChangeConnectorStyleCommandFactory extends TrackedCommandFactory<Command<ChangeConnectorStyleCommandArgs>, ChangeConnectorStyleCommandArgs> {
+
+    private final ElementIdManager elementIdManager;
+
+    public ChangeConnectorStyleCommandFactory(ElementIdManager elementIdManager,
+                                              Manager manager, ExecutedCommandList executedCommandList,
+                                              MessageConstructor messageConstructor) {
+        super(manager, executedCommandList, messageConstructor);
+        this.elementIdManager = elementIdManager;
+    }
+
+    /**
+     * Creates a command object
+     *
+     * @param args the arguments for the command
+     * @return a command of the specified type
+     */
+    @Override
+    public Command<ChangeConnectorStyleCommandArgs> create(ChangeConnectorStyleCommandArgs args) {
+        return new ChangeConnectorStyleCommand(args, elementIdManager);
+    }
+}

--- a/src/main/java/carleton/sysc4907/command/CommandListCompressor.java
+++ b/src/main/java/carleton/sysc4907/command/CommandListCompressor.java
@@ -20,7 +20,8 @@ public class CommandListCompressor {
             EditTextCommandArgs.class,
             MoveCommandArgs.class,
             RemoveCommandArgs.class,
-            ResizeCommandArgs.class
+            ResizeCommandArgs.class,
+            ChangeConnectorStyleCommandArgs.class
     };
 
     public CommandListCompressor(DiagramModel diagramModel, ElementIdManager elementIdManager) {

--- a/src/main/java/carleton/sysc4907/command/args/ChangeConnectorStyleCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/ChangeConnectorStyleCommandArgs.java
@@ -1,0 +1,12 @@
+package carleton.sysc4907.command.args;
+
+import carleton.sysc4907.controller.element.arrows.ConnectorType;
+
+import java.io.Serializable;
+
+public record ChangeConnectorStyleCommandArgs(long elementId, ConnectorType type) implements Serializable, CommandArgs {
+    @Override
+    public long[] getElementIds() {
+        return new long[] {elementId};
+    }
+}

--- a/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
+++ b/src/main/java/carleton/sysc4907/communications/MessageInterpreter.java
@@ -61,6 +61,7 @@ public class MessageInterpreter {
         ResizeCommandFactory resizeCommandFactory,
         EditTextCommandFactory editTextCommandFactory,
         ConnectorMovePointCommandFactory connectorMovePointCommandFactory,
+        ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory,
         MessageConstructor messageConstructor
     ) {
         this(messageConstructor);
@@ -70,7 +71,8 @@ public class MessageInterpreter {
                 moveCommandFactory,
                 resizeCommandFactory,
                 editTextCommandFactory,
-                connectorMovePointCommandFactory);
+                connectorMovePointCommandFactory,
+                changeConnectorStyleCommandFactory);
     }
 
     /**
@@ -87,13 +89,15 @@ public class MessageInterpreter {
             MoveCommandFactory moveCommandFactory,
             ResizeCommandFactory resizeCommandFactory,
             EditTextCommandFactory editTextCommandFactory,
-            ConnectorMovePointCommandFactory connectorMovePointCommandFactory) {
+            ConnectorMovePointCommandFactory connectorMovePointCommandFactory,
+            ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory) {
         commandFactories.put(AddCommandArgs.class, addCommandFactory);
         commandFactories.put(RemoveCommandArgs.class, removeCommandFactory);
         commandFactories.put(MoveCommandArgs.class, moveCommandFactory);
         commandFactories.put(ResizeCommandArgs.class, resizeCommandFactory);
         commandFactories.put(EditTextCommandArgs.class, editTextCommandFactory);
         commandFactories.put(ConnectorMovePointCommandArgs.class, connectorMovePointCommandFactory);
+        commandFactories.put(ChangeConnectorStyleCommandArgs.class, changeConnectorStyleCommandFactory);
     }
 
     /**

--- a/src/main/java/carleton/sysc4907/controller/ConnectorFormattingPanelController.java
+++ b/src/main/java/carleton/sysc4907/controller/ConnectorFormattingPanelController.java
@@ -1,0 +1,77 @@
+package carleton.sysc4907.controller;
+
+import carleton.sysc4907.command.ChangeConnectorStyleCommandFactory;
+import carleton.sysc4907.command.args.AddCommandArgs;
+import carleton.sysc4907.command.args.ChangeConnectorStyleCommandArgs;
+import carleton.sysc4907.controller.element.ArrowConnectorElementController;
+import carleton.sysc4907.controller.element.arrows.ConnectorType;
+import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.ElementIdManager;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.collections.ListChangeListener;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.layout.VBox;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ConnectorFormattingPanelController {
+
+    @FXML
+    private VBox connectorStyleContainer;
+
+    private final DiagramModel diagramModel;
+    private final ElementIdManager elementIdManager;
+    private final ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory;
+
+    public ConnectorFormattingPanelController(
+            DiagramModel diagramModel,
+            ElementIdManager elementIdManager,
+            ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory) {
+        this.diagramModel = diagramModel;
+        this.elementIdManager = elementIdManager;
+        this.changeConnectorStyleCommandFactory = changeConnectorStyleCommandFactory;
+    }
+
+    @FXML
+    public void initialize() {
+        List<Button> buttons = new LinkedList<>();
+        for (ConnectorType type : ConnectorType.values()) {
+            buttons.add(createStyleButton(type));
+        }
+        connectorStyleContainer.getChildren().addAll(buttons);
+        diagramModel.getSelectedElements().addListener(new ListChangeListener<DiagramElement>() {
+            @Override
+            public void onChanged(Change<? extends DiagramElement> change) {
+                boolean arrowSelected = false;
+                var selectedElements = diagramModel.getSelectedElements();
+                for (var element : selectedElements) {
+                    var controller = elementIdManager.getElementControllerById(element.getElementId());
+                    if (controller instanceof ArrowConnectorElementController) {
+                        arrowSelected = true;
+                        break;
+                    }
+                }
+                connectorStyleContainer.setDisable(!arrowSelected);
+            }
+        });
+    }
+
+    private Button createStyleButton(ConnectorType type) {
+        Button button = new Button(type.toString());
+        button.setOnAction(actionEvent -> {
+            var selectedElements = diagramModel.getSelectedElements();
+            for (var element : selectedElements) {
+                var elementId = element.getElementId();
+                var controller = elementIdManager.getElementControllerById(elementId);
+                if (controller instanceof ArrowConnectorElementController arrowConnectorElementController) {
+                    var args = new ChangeConnectorStyleCommandArgs(elementId, type);
+                    var command = changeConnectorStyleCommandFactory.createTracked(args);
+                    command.execute();
+                }
+            }
+        });
+        return button;
+    }
+}

--- a/src/main/java/carleton/sysc4907/controller/element/ArrowConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ArrowConnectorElementController.java
@@ -19,6 +19,8 @@ public class ArrowConnectorElementController extends ConnectorElementController 
     private final double DASHED_OFFSET = 4;
     private final ArrowheadFactory arrowheadFactory;
 
+    private ConnectorType connectorType = null;
+
     private Arrowhead arrowhead;
 
     @FXML
@@ -70,11 +72,13 @@ public class ArrowConnectorElementController extends ConnectorElementController 
      * @param type the new ArrowheadType to use for this connector
      */
     public void setArrowheadType(ConnectorType type) {
+        connectorType = type;
         arrowhead = arrowheadFactory.createArrowhead(type);
         makeArrowheadPath();
     }
 
     public void setPathStyle(ConnectorType type) {
+        connectorType = type;
         if (type == ConnectorType.IMPLEMENTATION) {
             connectorPath.getStrokeDashArray().add(DASHED_OFFSET);
         } else {
@@ -104,9 +108,14 @@ public class ArrowConnectorElementController extends ConnectorElementController 
         }
     }
 
+    public ConnectorType getConnectorType() {
+        return connectorType;
+    }
+
     @Override
     public void initialize() {
         super.initialize();
         setArrowheadType(ConnectorType.ASSOCIATION); // default arrowhead
+        setPathStyle(ConnectorType.ASSOCIATION);
     }
 }

--- a/src/main/java/carleton/sysc4907/controller/element/ArrowConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ArrowConnectorElementController.java
@@ -4,11 +4,10 @@ import carleton.sysc4907.command.ConnectorMovePointCommandFactory;
 import carleton.sysc4907.command.MoveCommandFactory;
 import carleton.sysc4907.controller.element.arrows.Arrowhead;
 import carleton.sysc4907.controller.element.arrows.ArrowheadFactory;
-import carleton.sysc4907.controller.element.arrows.ArrowheadType;
+import carleton.sysc4907.controller.element.arrows.ConnectorType;
 import carleton.sysc4907.controller.element.pathing.PathingStrategy;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.fxml.FXML;
 import javafx.scene.shape.Path;
 
@@ -17,6 +16,7 @@ import javafx.scene.shape.Path;
  */
 public class ArrowConnectorElementController extends ConnectorElementController {
 
+    private final double DASHED_OFFSET = 4;
     private final ArrowheadFactory arrowheadFactory;
 
     private Arrowhead arrowhead;
@@ -69,9 +69,17 @@ public class ArrowConnectorElementController extends ConnectorElementController 
      * Sets the arrowhead type to use for this connector.
      * @param type the new ArrowheadType to use for this connector
      */
-    public void setArrowheadType(ArrowheadType type) {
+    public void setArrowheadType(ConnectorType type) {
         arrowhead = arrowheadFactory.createArrowhead(type);
         makeArrowheadPath();
+    }
+
+    public void setPathStyle(ConnectorType type) {
+        if (type == ConnectorType.IMPLEMENTATION) {
+            connectorPath.getStrokeDashArray().add(DASHED_OFFSET);
+        } else {
+            connectorPath.getStrokeDashArray().clear();
+        }
     }
 
     @Override
@@ -91,12 +99,14 @@ public class ArrowConnectorElementController extends ConnectorElementController 
                     adjustX(getEndX()), adjustY(getEndY()),
                     isEndHorizontal.get(), this.pathingStrategy.get().isDirectPath()
             );
+        } else {
+            arrowheadPath.getElements().clear();
         }
     }
 
     @Override
     public void initialize() {
         super.initialize();
-        setArrowheadType(ArrowheadType.ASSOCIATION); // default arrowhead
+        setArrowheadType(ConnectorType.ASSOCIATION); // default arrowhead
     }
 }

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -40,7 +40,7 @@ public class ConnectorElementController extends DiagramElementController {
     private boolean isEndSnapping = false;
 
     @FXML
-    private Path connectorPath;
+    protected Path connectorPath;
     protected ObjectProperty<PathingStrategy> pathingStrategy = new SimpleObjectProperty<>();
     @FXML
     private Path pathHitbox;

--- a/src/main/java/carleton/sysc4907/controller/element/arrows/ArrowheadFactory.java
+++ b/src/main/java/carleton/sysc4907/controller/element/arrows/ArrowheadFactory.java
@@ -11,12 +11,12 @@ public class ArrowheadFactory {
      * @param type the type of arrowhead to create
      * @return the newly created Arrowhead
      */
-    public Arrowhead createArrowhead(ArrowheadType type) {
+    public Arrowhead createArrowhead(ConnectorType type) {
         switch (type) {
             case AGGREGATION -> {
                 return new AggregationArrowhead();
             }
-            case INHERITANCE -> {
+            case INHERITANCE, IMPLEMENTATION -> {
                 return new InheritanceArrowhead();
             }
             case COMPOSITION -> {

--- a/src/main/java/carleton/sysc4907/controller/element/arrows/ConnectorType.java
+++ b/src/main/java/carleton/sysc4907/controller/element/arrows/ConnectorType.java
@@ -1,9 +1,10 @@
 package carleton.sysc4907.controller.element.arrows;
 
-public enum ArrowheadType {
+public enum ConnectorType {
     AGGREGATION,
     COMPOSITION,
     ASSOCIATION,
     INHERITANCE,
+    IMPLEMENTATION,
     NONE
 }

--- a/src/main/resources/carleton/sysc4907/view/ConnectorFormattingPanel.fxml
+++ b/src/main/resources/carleton/sysc4907/view/ConnectorFormattingPanel.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.image.Image?>
+<TitledPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="carleton.sysc4907.controller.ConnectorFormattingPanelController">
+    <text>Element Library</text>
+    <VBox fx:id="connectorStyleContainer" disable="true">
+
+    </VBox>
+</TitledPane>

--- a/src/main/resources/carleton/sysc4907/view/ConnectorFormattingPanel.fxml
+++ b/src/main/resources/carleton/sysc4907/view/ConnectorFormattingPanel.fxml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import java.util.*?>
-<?import javafx.scene.*?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
 
-<?import javafx.scene.image.ImageView?>
-<?import javafx.scene.image.Image?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.VBox?>
 <TitledPane xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="carleton.sysc4907.controller.ConnectorFormattingPanelController">
-    <text>Element Library</text>
-    <VBox fx:id="connectorStyleContainer" disable="true">
-
+    <text>Connector Formatting</text>
+    <VBox>
+        <ComboBox fx:id="connectorStyle">
+            <!--- Set connector styles dynamically -->
+        </ComboBox>
+        <VBox.margin>
+            <Insets top="10.0" bottom="10.0"/>
+        </VBox.margin>
     </VBox>
 </TitledPane>

--- a/src/main/resources/carleton/sysc4907/view/DiagramEditorScreen.fxml
+++ b/src/main/resources/carleton/sysc4907/view/DiagramEditorScreen.fxml
@@ -13,6 +13,7 @@
         <!--        Move style to its own CSS stylesheet -->
         <VBox prefWidth="400.0">
             <fx:include source="FormattingPanel.fxml"/>
+            <fx:include source="ConnectorFormattingPanel.fxml"/>
             <fx:include source="ElementLibraryPanel.fxml" fx:id="elementLibraryPanel"/>
         </VBox>
     </left>

--- a/src/test/java/carleton/sysc4907/command/ConnectorChangeStyleCommandTest.java
+++ b/src/test/java/carleton/sysc4907/command/ConnectorChangeStyleCommandTest.java
@@ -1,0 +1,40 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ChangeConnectorStyleCommandArgs;
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.controller.element.ArrowConnectorElementController;
+import carleton.sysc4907.controller.element.ConnectorElementController;
+import carleton.sysc4907.controller.element.arrows.ConnectorType;
+import carleton.sysc4907.processing.ElementIdManager;
+import javafx.collections.ObservableMap;
+import javafx.scene.Node;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectorChangeStyleCommandTest {
+    @Mock
+    private ArrowConnectorElementController mockConnectorController;
+    @Mock
+    private ElementIdManager mockElementIdManager;
+
+    @ParameterizedTest
+    @EnumSource(ConnectorType.class)
+    void execute(ConnectorType type) {
+        long testId = 12L;
+        when(mockElementIdManager.getElementControllerById(testId)).thenReturn(mockConnectorController);
+
+        var args = new ChangeConnectorStyleCommandArgs(testId, type);
+        var command = new ChangeConnectorStyleCommand(args, mockElementIdManager);
+        command.execute();
+
+        verify(mockConnectorController).setPathStyle(type);
+        verify(mockConnectorController).setArrowheadType(type);
+    }
+}

--- a/src/test/java/carleton/sysc4907/command/ConnectorChangeStyleFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/ConnectorChangeStyleFactoryTest.java
@@ -1,0 +1,41 @@
+package carleton.sysc4907.command;
+
+import carleton.sysc4907.command.args.ChangeConnectorStyleCommandArgs;
+import carleton.sysc4907.command.args.ConnectorMovePointCommandArgs;
+import carleton.sysc4907.communications.Manager;
+import carleton.sysc4907.communications.MessageConstructor;
+import carleton.sysc4907.controller.element.arrows.ConnectorType;
+import carleton.sysc4907.model.ExecutedCommandList;
+import carleton.sysc4907.processing.ElementIdManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectorChangeStyleFactoryTest {
+
+    @Mock
+    private ElementIdManager mockElementIdManager;
+
+    @Mock
+    private ExecutedCommandList mockExecutedCommandList;
+
+    @Mock
+    private MessageConstructor mockMessageConstructor;
+
+    @Test
+    void createCommand() {
+        long testId = 12L;
+        Manager mockManager = Mockito.mock(Manager.class);
+        var args = new ChangeConnectorStyleCommandArgs(testId, ConnectorType.INHERITANCE);
+        var factory = new ChangeConnectorStyleCommandFactory(mockElementIdManager, mockManager, mockExecutedCommandList, mockMessageConstructor);
+
+        var command = factory.create(args);
+
+        assertEquals(ChangeConnectorStyleCommand.class, command.getClass());
+    }
+}

--- a/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
+++ b/src/test/java/carleton/sysc4907/communications/MessageInterpreterTest.java
@@ -30,6 +30,8 @@ public class MessageInterpreterTest {
     @Mock
     private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
     @Mock
+    private ChangeConnectorStyleCommandFactory changeConnectorStyleCommandFactory;
+    @Mock
     private MessageConstructor messageConstructor;
     @Mock
     private Manager manager;
@@ -51,6 +53,7 @@ public class MessageInterpreterTest {
                 resizeCommandFactory,
                 editTextCommandFactory,
                 connectorMovePointCommandFactory,
+                changeConnectorStyleCommandFactory,
                 messageConstructor
         );
         interpreter.setManager(manager);
@@ -80,6 +83,7 @@ public class MessageInterpreterTest {
                 resizeCommandFactory,
                 editTextCommandFactory,
                 connectorMovePointCommandFactory,
+                changeConnectorStyleCommandFactory,
                 messageConstructor
         );
         interpreter.setManager(manager);
@@ -106,6 +110,7 @@ public class MessageInterpreterTest {
                 resizeCommandFactory,
                 editTextCommandFactory,
                 connectorMovePointCommandFactory,
+                changeConnectorStyleCommandFactory,
                 messageConstructor
         );
         var payload = "Not an args object";

--- a/src/test/java/carleton/sysc4907/controller/element/ArrowConnectorElementControllerTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/ArrowConnectorElementControllerTest.java
@@ -1,0 +1,114 @@
+package carleton.sysc4907.controller.element;
+
+import carleton.sysc4907.controller.element.arrows.Arrowhead;
+import carleton.sysc4907.controller.element.arrows.ArrowheadFactory;
+import carleton.sysc4907.controller.element.arrows.ConnectorType;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.shape.Path;
+import javafx.scene.shape.PathElement;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.ArgumentMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ArrowConnectorElementControllerTest extends ConnectorElementControllerTest {
+
+    @Mock
+    protected ArrowheadFactory arrowheadFactory;
+
+    @Mock
+    protected Arrowhead arrowhead;
+
+    @Mock
+    protected DiagramElement element;
+
+    @Mock
+    protected Path connectorPath;
+
+    @Mock
+    protected ObservableList<Double> mockStrokeDashArray;
+    @Mock
+    protected Path arrowheadPath;
+
+    @Mock
+    protected ObservableList<PathElement> mockPathElementsList;
+
+    @Override
+    protected ConnectorElementController createController() {
+        var connector = new ArrowConnectorElementController(
+                movePreviewCreator,
+                moveCommandFactory,
+                diagramModel,
+                connectorHandleCreator,
+                connectorMovePointPreviewCreator,
+                connectorMovePointCommandFactory,
+                pathingStrategy,
+                arrowheadFactory
+        );
+        try {
+            Field elementField = DiagramElementController.class.getDeclaredField("element");
+            elementField.setAccessible(true);
+            elementField.set(connector, element);
+            Field arrowheadPathField = connector.getClass().getDeclaredField("arrowheadPath");
+            arrowheadPathField.setAccessible(true);
+            arrowheadPathField.set(connector, arrowheadPath);
+            Field connectorPathField = connector.getClass().getSuperclass().getDeclaredField("connectorPath");
+            connectorPathField.setAccessible(true);
+            connectorPathField.set(connector, connectorPath);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return connector;
+    }
+
+    @ParameterizedTest
+    @EnumSource(ConnectorType.class)
+    void testSetArrowheadType(ConnectorType type) {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(any(ListChangeListener.class));
+        Mockito.lenient().when(element.getLayoutX()).thenReturn(0.0);
+        Mockito.lenient().when(element.getLayoutY()).thenReturn(0.0);
+        Mockito.lenient().when(arrowheadPath.getElements()).thenReturn(mockPathElementsList);
+        if (type != ConnectorType.NONE) {
+            Mockito.when(arrowheadFactory.createArrowhead(type)).thenReturn(arrowhead);
+        } else {
+            Mockito.when(arrowheadFactory.createArrowhead(type)).thenReturn(null);
+        }
+        var controller = (ArrowConnectorElementController) createController();
+        controller.setArrowheadType(type);
+
+        if (type != ConnectorType.NONE) {
+            Mockito.verify(arrowhead).makeArrowheadPath(any(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyBoolean(), anyBoolean());
+        } else {
+            Mockito.verify(mockPathElementsList).clear();
+            Mockito.verify(arrowhead, Mockito.never()).makeArrowheadPath(any(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyBoolean(), anyBoolean());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ConnectorType.class)
+    void testSetPathStyle(ConnectorType type) {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(any(ListChangeListener.class));
+        Mockito.when(connectorPath.getStrokeDashArray()).thenReturn(mockStrokeDashArray);
+        var controller = (ArrowConnectorElementController) createController();
+        controller.setPathStyle(type);
+
+        if (type == ConnectorType.IMPLEMENTATION) {
+            Mockito.verify(mockStrokeDashArray).add(anyDouble());
+        } else {
+            Mockito.verify(mockStrokeDashArray).clear();
+        }
+    }
+}

--- a/src/test/java/carleton/sysc4907/controller/element/ConnectorElementControllerTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/ConnectorElementControllerTest.java
@@ -18,28 +18,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class ConnectorElementControllerTest {
 
     @Mock
-    private MovePreviewCreator movePreviewCreator;
+    protected MovePreviewCreator movePreviewCreator;
     @Mock
-    private MoveCommandFactory moveCommandFactory;
+    protected MoveCommandFactory moveCommandFactory;
     @Mock
-    private DiagramModel diagramModel;
+    protected DiagramModel diagramModel;
     @Mock
-    private ConnectorHandleCreator connectorHandleCreator;
+    protected ConnectorHandleCreator connectorHandleCreator;
 
     @Mock
-    private ConnectorMovePointPreviewCreator connectorMovePointPreviewCreator;
+    protected ConnectorMovePointPreviewCreator connectorMovePointPreviewCreator;
     @Mock
-    private ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
+    protected ConnectorMovePointCommandFactory connectorMovePointCommandFactory;
     @Mock
-    private PathingStrategy pathingStrategy;
+    protected PathingStrategy pathingStrategy;
     @Mock
-    private ObservableList<DiagramElement> mockSelectedElementsList;
+    protected ObservableList<DiagramElement> mockSelectedElementsList;
 
-    @Test
-    public void updateDirectionBothSnapped() {
-        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
-        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
-        var controller = new ConnectorElementController(
+    protected ConnectorElementController createController() {
+        return new ConnectorElementController(
                 movePreviewCreator,
                 moveCommandFactory,
                 diagramModel,
@@ -48,6 +45,13 @@ public class ConnectorElementControllerTest {
                 connectorMovePointCommandFactory,
                 pathingStrategy
         );
+    }
+
+    @Test
+    public void updateDirectionBothSnapped() {
+        Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
+        Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
+        var controller = createController();
         // Snap to vertical
         controller.setIsStartHorizontal(false);
         controller.setIsEndHorizontal(false);
@@ -69,15 +73,7 @@ public class ConnectorElementControllerTest {
     public void updateDirectionNoneSnappedStraight() {
         Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
         Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
-        var controller = new ConnectorElementController(
-                movePreviewCreator,
-                moveCommandFactory,
-                diagramModel,
-                connectorHandleCreator,
-                connectorMovePointPreviewCreator,
-                connectorMovePointCommandFactory,
-                pathingStrategy
-        );
+        var controller = createController();
         // Don't snap
         controller.setSnapStart(false);
         controller.setSnapEnd(false);
@@ -97,15 +93,7 @@ public class ConnectorElementControllerTest {
     public void updateDirectionNoneSnappedDiagonal() {
         Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
         Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
-        var controller = new ConnectorElementController(
-                movePreviewCreator,
-                moveCommandFactory,
-                diagramModel,
-                connectorHandleCreator,
-                connectorMovePointPreviewCreator,
-                connectorMovePointCommandFactory,
-                pathingStrategy
-        );
+        var controller = createController();
         // Don't snap
         controller.setSnapStart(false);
         controller.setSnapEnd(false);
@@ -124,15 +112,7 @@ public class ConnectorElementControllerTest {
     public void updateDirectionOneSnappedStraight() {
         Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
         Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
-        var controller = new ConnectorElementController(
-                movePreviewCreator,
-                moveCommandFactory,
-                diagramModel,
-                connectorHandleCreator,
-                connectorMovePointPreviewCreator,
-                connectorMovePointCommandFactory,
-                pathingStrategy
-        );
+        var controller = createController();
         // Snap only start to vertical, shouldn't change
         controller.setIsStartHorizontal(false);
         controller.setIsEndHorizontal(false);
@@ -154,15 +134,7 @@ public class ConnectorElementControllerTest {
     public void updateDirectionOneSnappedDiagonal() {
         Mockito.when(diagramModel.getSelectedElements()).thenReturn(mockSelectedElementsList);
         Mockito.doNothing().when(mockSelectedElementsList).addListener(Mockito.any(ListChangeListener.class));
-        var controller = new ConnectorElementController(
-                movePreviewCreator,
-                moveCommandFactory,
-                diagramModel,
-                connectorHandleCreator,
-                connectorMovePointPreviewCreator,
-                connectorMovePointCommandFactory,
-                pathingStrategy
-        );
+        var controller = createController();
         // Snap only end to vertical, shouldn't change
         controller.setIsStartHorizontal(false);
         controller.setIsEndHorizontal(true);

--- a/src/test/java/carleton/sysc4907/controller/element/arrows/ArrowheadFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/controller/element/arrows/ArrowheadFactoryTest.java
@@ -12,35 +12,35 @@ public class ArrowheadFactoryTest {
     @Test
     public void testCreateArrowheadAggregation() {
         var arrowheadFactory = new ArrowheadFactory();
-        var arrowhead = arrowheadFactory.createArrowhead(ArrowheadType.AGGREGATION);
+        var arrowhead = arrowheadFactory.createArrowhead(ConnectorType.AGGREGATION);
         assertTrue(arrowhead instanceof AggregationArrowhead);
     }
 
     @Test
     public void testCreateArrowheadComposition() {
         var arrowheadFactory = new ArrowheadFactory();
-        var arrowhead = arrowheadFactory.createArrowhead(ArrowheadType.COMPOSITION);
+        var arrowhead = arrowheadFactory.createArrowhead(ConnectorType.COMPOSITION);
         assertTrue(arrowhead instanceof CompositionArrowhead);
     }
 
     @Test
     public void testCreateArrowheadAssociation() {
         var arrowheadFactory = new ArrowheadFactory();
-        var arrowhead = arrowheadFactory.createArrowhead(ArrowheadType.ASSOCIATION);
+        var arrowhead = arrowheadFactory.createArrowhead(ConnectorType.ASSOCIATION);
         assertTrue(arrowhead instanceof AssociationArrowhead);
     }
 
     @Test
     public void testCreateArrowheadInheritance() {
         var arrowheadFactory = new ArrowheadFactory();
-        var arrowhead = arrowheadFactory.createArrowhead(ArrowheadType.INHERITANCE);
+        var arrowhead = arrowheadFactory.createArrowhead(ConnectorType.INHERITANCE);
         assertTrue(arrowhead instanceof InheritanceArrowhead);
     }
 
     @Test
     public void testCreateArrowheadNone() {
         var arrowheadFactory = new ArrowheadFactory();
-        var arrowhead = arrowheadFactory.createArrowhead(ArrowheadType.NONE);
+        var arrowhead = arrowheadFactory.createArrowhead(ConnectorType.NONE);
         assertNull(arrowhead);
     }
 }


### PR DESCRIPTION
Allows users to set the style of all selected arrow connectors from among the following connectors: aggregation, composition, inheritance, implementation, association, and no arrowhead (line).

Missing UI tests.