### PR TITLE
Remove rectangle from element library panel

### DIFF
--- a/src/main/resources/carleton/sysc4907/templates.xml
+++ b/src/main/resources/carleton/sysc4907/templates.xml
@@ -2,7 +2,7 @@
 <templates>
     <!-- FXML paths must be specified relative to the resources directory, with a leading slash.-->
     <!-- Element type names should be human-readable: they are displayed on the UI! -->
-    <template type="Rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>
+<!--    <template type="Rectangle" fxml="/carleton/sysc4907/view/element/Rectangle.fxml"/>-->
     <template type="UML Comment" fxml="/carleton/sysc4907/view/element/UmlComment.fxml"/>
     <template type="UML Class" fxml="/carleton/sysc4907/view/element/UmlClass.fxml"/>
     <template type="Line" fxml="/carleton/sysc4907/view/element/Connector.fxml"/>


### PR DESCRIPTION
The rectangle was always meant to be a debug element, so this is removing it for our demo for the poster fair.