### PR TITLE
Add keybinds and mnemonics for certain actions

### DIFF
--- a/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
+++ b/src/main/java/carleton/sysc4907/controller/DiagramMenuBarController.java
@@ -1,19 +1,18 @@
 package carleton.sysc4907.controller;
 
-import carleton.sysc4907.command.Command;
-import carleton.sysc4907.command.MoveCommandFactory;
 import carleton.sysc4907.command.RemoveCommandFactory;
 import carleton.sysc4907.command.args.RemoveCommandArgs;
-import carleton.sysc4907.model.ExecutedCommandList;
 import carleton.sysc4907.processing.FileSaver;
 import carleton.sysc4907.view.DiagramElement;
 import carleton.sysc4907.model.DiagramModel;
 import javafx.fxml.FXML;
-import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
-import javafx.scene.layout.Pane;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
@@ -68,6 +67,7 @@ public class DiagramMenuBarController {
     /**
      * Deletes all selected elements from the diagram.
      */
+    @FXML
     public void deleteSelectedElements() {
         List<Long> toDelete = diagramModel.getSelectedElements().stream().map(DiagramElement::getElementId).toList();
         if (!toDelete.isEmpty()) {
@@ -82,12 +82,12 @@ public class DiagramMenuBarController {
      * otherwise prompts the user to choose a file instead.
      */
     @FXML
-    public void saveDiagram(ActionEvent event) {
+    public void saveDiagram() {
         if (diagramModel.getLoadedFilePath() != null) {
             fileSaver.save();
         } else {
             // Prompt the user for a file if this is a new diagram
-            saveDiagramAs(event);
+            saveDiagramAs();
         }
     }
 
@@ -95,7 +95,7 @@ public class DiagramMenuBarController {
      * Saves the diagram to a file chosen via file chooser.
      */
     @FXML
-    public void saveDiagramAs(ActionEvent event) {
+    public void saveDiagramAs() {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Choose Save Location");
         Stage stage = (Stage) menuBar.getScene().getWindow();
@@ -123,5 +123,27 @@ public class DiagramMenuBarController {
     @FXML
     public void initialize() {
         deleteElement.disableProperty().bind(diagramModel.getIsElementSelectedProperty().not());
+        menuBar.sceneProperty().addListener((observableValue, scene, newScene) -> {
+            if (newScene == null) return;
+            var root = newScene.getRoot();
+            System.out.println(root);
+            root.addEventHandler(KeyEvent.KEY_PRESSED, keyEvent -> {
+                if (keyEvent.getCode() == KeyCode.DELETE && diagramModel.getIsElementSelectedProperty().get()) {
+                    System.out.println("DELETE key pressed");
+                    deleteSelectedElements();
+                }
+            });
+            var saveKeyCombination = new KeyCodeCombination(KeyCode.S, KeyCombination.CONTROL_DOWN);
+            var saveAsKeyCombination = new KeyCodeCombination(KeyCode.S, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN);
+            root.addEventHandler(KeyEvent.KEY_PRESSED, keyEvent -> {
+                if (saveAsKeyCombination.match(keyEvent)) {
+                    System.out.println("Ctrl+Shift+S pressed");
+                    saveDiagramAs();
+                } else if (saveKeyCombination.match(keyEvent)) {
+                    System.out.println("Ctrl+S pressed");
+                    saveDiagram();
+                }
+            });
+        });
     }
 }

--- a/src/main/java/carleton/sysc4907/controller/StartScreenController.java
+++ b/src/main/java/carleton/sysc4907/controller/StartScreenController.java
@@ -190,6 +190,7 @@ public class StartScreenController {
         try {
             loader.createAndLoad(stage, preferences.getUsername(), roomCode);
         } catch (IOException e) {
+            e.printStackTrace();
             Alert alert = new Alert(Alert.AlertType.ERROR);
             alert.setTitle("Error");
             alert.setHeaderText("Application error");

--- a/src/main/resources/carleton/sysc4907/view/DiagramMenu.fxml
+++ b/src/main/resources/carleton/sysc4907/view/DiagramMenu.fxml
@@ -10,19 +10,19 @@
       xmlns:fx="http://javafx.com/fxml"
       fx:controller="carleton.sysc4907.controller.DiagramMenuBarController"
       fx:id="menuBar">
-    <Menu text="File">
-        <MenuItem text="New" disable="true"/>
-        <MenuItem text="Open" disable="true"/>
-        <MenuItem text="Save" onAction="#saveDiagram"/>
-        <MenuItem text="Save As" onAction="#saveDiagramAs"/>
+    <Menu text="_File">
+        <MenuItem text="_New" disable="true"/>
+        <MenuItem text="_Open" disable="true"/>
+        <MenuItem text="_Save" onAction="#saveDiagram"/>
+        <MenuItem text="Save _As" onAction="#saveDiagramAs"/>
         <SeparatorMenuItem/>
-        <MenuItem text="Export To Image" disable="true"/>
-        <MenuItem text="Export To PDF" disable="true"/>
+        <MenuItem text="Export To _Image" disable="true"/>
+        <MenuItem text="Export To _PDF" disable="true"/>
         <SeparatorMenuItem/>
-        <MenuItem text="Exit" onAction="#closeApplication"/>
+        <MenuItem text="E_xit" onAction="#closeApplication"/>
     </Menu>
-    <Menu text="Edit">
-        <MenuItem text="Delete Selected" onAction="#deleteSelectedElements" fx:id="deleteElement"/>
+    <Menu text="_Edit">
+        <MenuItem text="_Delete Selected" onAction="#deleteSelectedElements" fx:id="deleteElement"/>
     </Menu>
     <Menu text="View">
 

--- a/src/test/java/carleton/sysc4907/ui/view/DiagramMenuTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/DiagramMenuTest.java
@@ -1,0 +1,135 @@
+package carleton.sysc4907.ui.view;
+
+import carleton.sysc4907.DependencyInjector;
+import carleton.sysc4907.command.Command;
+import carleton.sysc4907.command.RemoveCommandFactory;
+import carleton.sysc4907.command.args.RemoveCommandArgs;
+import carleton.sysc4907.controller.DiagramMenuBarController;
+import carleton.sysc4907.model.DiagramModel;
+import carleton.sysc4907.processing.FileSaver;
+import carleton.sysc4907.view.DiagramElement;
+import javafx.application.Platform;
+import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(ApplicationExtension.class)
+public class DiagramMenuTest {
+
+    @Mock
+    private DiagramModel mockDiagramModel;
+
+    @Mock
+    private BooleanProperty mockIsSelectedElementsProperty;
+    private ObservableList<DiagramElement> selectedElementsList = FXCollections.observableList(new LinkedList<>());
+    @Mock
+    private BooleanBinding booleanBinding;
+    @Mock
+    private RemoveCommandFactory mockRemoveCommandFactory;
+    @Mock
+    private FileSaver mockFileSaver;
+    @Mock
+    private DiagramElement mockElement;
+
+    @Mock
+    private DiagramElement mockElement2;
+    @Mock
+    private Command<RemoveCommandArgs> removeCommand;
+
+    @Mock
+    private File mockFile;
+
+    private Pane root;
+
+    @Start
+    private void start(Stage stage) throws IOException {
+        selectedElementsList.clear();
+        selectedElementsList.add(mockElement);
+        selectedElementsList.add(mockElement2);
+        when(mockDiagramModel.getIsElementSelectedProperty()).thenReturn(mockIsSelectedElementsProperty);
+        when(mockIsSelectedElementsProperty.not()).thenReturn(booleanBinding);
+        DependencyInjector injector = new DependencyInjector();
+        injector.addInjectionMethod(DiagramMenuBarController.class,
+                () -> new DiagramMenuBarController(mockDiagramModel, mockRemoveCommandFactory, mockFileSaver));
+        root = new Pane();
+        root.setMinHeight(100);
+        Scene scene = new Scene(root);
+        root.getChildren().add(injector.load("view/DiagramMenu.fxml"));
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    @Test
+    public void testDeleteViaMnemonics(FxRobot robot) throws InterruptedException {
+        when(mockDiagramModel.getSelectedElements()).thenReturn(selectedElementsList);
+        when(mockRemoveCommandFactory.createTracked(any())).thenReturn(removeCommand);
+
+        TimeUnit.MILLISECONDS.sleep(100);
+        robot.press(KeyCode.ALT, KeyCode.E, KeyCode.D);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        verify(mockRemoveCommandFactory, times(1)).createTracked(any());
+        verify(removeCommand, times(1)).execute();
+    }
+
+    @Test
+    public void testDeleteViaKeybind(FxRobot robot) throws InterruptedException {
+        when(mockDiagramModel.getSelectedElements()).thenReturn(selectedElementsList);
+        when(mockRemoveCommandFactory.createTracked(any())).thenReturn(removeCommand);
+        when(mockIsSelectedElementsProperty.get()).thenReturn(true);
+
+        Platform.runLater(() -> root.requestFocus());
+        TimeUnit.MILLISECONDS.sleep(300);
+        robot.press(KeyCode.DELETE);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        verify(mockRemoveCommandFactory).createTracked(any());
+        verify(removeCommand).execute();
+    }
+
+    @Test
+    public void testSaveViaMnemonicsWhenAlreadySaved(FxRobot robot) throws InterruptedException {
+        when(mockFileSaver.save()).thenReturn(true);
+        when(mockDiagramModel.getLoadedFilePath()).thenReturn("notNull");
+
+        TimeUnit.MILLISECONDS.sleep(100);
+        robot.press(KeyCode.ALT, KeyCode.F, KeyCode.S);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        verify(mockFileSaver).save();
+    }
+
+    @Test
+    public void testSaveViaKeybindWhenAlreadySaved(FxRobot robot) throws InterruptedException {
+        when(mockFileSaver.save()).thenReturn(true);
+        when(mockDiagramModel.getLoadedFilePath()).thenReturn("notNull");
+
+        Platform.runLater(() -> root.requestFocus());
+        TimeUnit.MILLISECONDS.sleep(300);
+        robot.press(KeyCode.CONTROL, KeyCode.S);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        verify(mockFileSaver).save();
+    }
+}


### PR DESCRIPTION
Keybinds:
- DELETE for deleting selected elements
- CTRL+S for save
- CTRL+SHIFT+S for save as
These aren't documented in the app right now, we should add them to the README

Mnemonics:
To use them, you need to see the first letter of some menu options underlined. If this isn't the case, press Alt once and it should happen. Once you do that, pressing the underline key should open the corresponding menu or activate the corresponding menu item, as if it had been pressed.

Tests:
Couldn't make tests for the save as, because I couldn't mock the file chooser dialog constructor (mockConstruct was ignored and there's no Platform.runLater workaround). The delete and regular save (when a file path is already defined) are tested both via mnemonics and direct keybinds.