### PR TITLE
Support canceling drag operations via right-click

### DIFF
--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -163,12 +163,14 @@ public class ConnectorElementController extends DiagramElementController {
             var handle = connectorHandleCreator.createMovePointHandle(element, startX, startY);
             handle.setOnDragDetected(this::handleDragDetectedStartMovePoint);
             handle.setOnMouseDragged(event -> handleMouseDraggedMovePreviewPoint(event, true));
-            handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, true));
+            handle.setOnMouseReleased(event -> handleMouseReleasedMovePoint(event, true));
+            handle.setOnMousePressed(this::handleCancelDragOperations);
             handles.add(handle);
             handle = connectorHandleCreator.createMovePointHandle(element, endX, endY);
             handle.setOnDragDetected(this::handleDragDetectedStartMovePoint);
             handle.setOnMouseDragged(event -> handleMouseDraggedMovePreviewPoint(event, false));
-            handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, false));
+            handle.setOnMouseReleased(event -> handleMouseReleasedMovePoint(event, false));
+            handle.setOnMousePressed(this::handleCancelDragOperations);
             handles.add(handle);
         } else {
             for (Node handle : handles) {
@@ -259,6 +261,16 @@ public class ConnectorElementController extends DiagramElementController {
         }
     }
 
+    @Override
+    protected void handleCancelDragOperations(MouseEvent event) {
+        super.handleCancelDragOperations(event);
+        if (event.isSecondaryButtonDown()) {
+            movePointDragging = false;
+            connectorMovePointPreviewCreator.deleteMovePreview(element, previewController);
+            snapHandleProvider.setAllHandlesVisible(false);
+        }
+    }
+
     /**
      * Handler for the endpoint move handles, starts a drag operation.
      * @param event the mouse event
@@ -304,7 +316,7 @@ public class ConnectorElementController extends DiagramElementController {
      * @param event the mouse release event
      * @param isStart true if the start point was the one dragged, false if it was the end point
      */
-    private void handleMouseReleasedResize(MouseEvent event, boolean isStart) {
+    private void handleMouseReleasedMovePoint(MouseEvent event, boolean isStart) {
         if (!movePointDragging) {
             return;
         }

--- a/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/DiagramElementController.java
@@ -80,6 +80,7 @@ public abstract class DiagramElementController {
         addMouseHandler(MouseEvent.MOUSE_DRAGGED, this::handleMouseDraggedMovePreview);
         addMouseHandler(MouseEvent.MOUSE_RELEASED, this::handleMouseReleasedDeletePreview);
         addMouseHandler(MouseEvent.MOUSE_PRESSED, this::handleSelect);
+        addMouseHandler(MouseEvent.MOUSE_PRESSED, this::handleCancelDragOperations);
         addMouseHandler(MouseEvent.MOUSE_PRESSED, (evt) -> element.requestFocus());
         snapHandles = new ArrayList<>();
         snapHandleProvider = SnapHandleProvider.getSingleton();
@@ -195,6 +196,13 @@ public abstract class DiagramElementController {
                 diagramModel.getSelectedElements().clear();
                 diagramModel.getSelectedElements().add(element);
             }
+        }
+    }
+
+    protected void handleCancelDragOperations(MouseEvent event) {
+        if (event.isSecondaryButtonDown()) {
+            dragging = false;
+            previewCreator.deleteMovePreview(element, preview);
         }
     }
 

--- a/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ResizableElementController.java
@@ -96,6 +96,7 @@ public abstract class ResizableElementController extends DiagramElementControlle
             handle.setOnDragDetected(this::handleDragDetectedStartResize);
             handle.setOnMouseDragged(event -> handleMouseDraggedResizePreview(event, isTop, isRight));
             handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, isTop, isRight));
+            handle.setOnMousePressed(this::handleCancelDragOperations);
             handle.setOnMouseClicked(Event::consume);
             resizeHandles.add(handle);
         }
@@ -110,6 +111,16 @@ public abstract class ResizableElementController extends DiagramElementControlle
             }
             resizeHandles.clear();
         }
+    }
+
+    @Override
+    protected void handleCancelDragOperations(MouseEvent event) {
+        super.handleCancelDragOperations(event);
+        if (event.isSecondaryButtonDown()) {
+            resizeDragging = false;
+            resizePreviewCreator.deleteResizePreview(element, preview);
+        }
+
     }
 
     private void handleDragDetectedStartResize(MouseEvent event) {

--- a/src/test/java/carleton/sysc4907/ui/view/DiagramElementTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/DiagramElementTest.java
@@ -163,6 +163,17 @@ public abstract class DiagramElementTest {
         assertTrue(deltaY < 10);
     }
 
+    @Test
+    protected void testDragMoveCancel(FxRobot robot) {
+        var x = element.getLayoutX();
+        var y = element.getLayoutY();
+        robot.drag(element, MouseButton.PRIMARY).moveBy(100, 150).clickOn(MouseButton.SECONDARY).drop();
+        // Check that dragged position is correct
+        assertEquals(x, element.getLayoutX());
+        assertEquals(y, element.getLayoutY());
+        verify(elementIdManager, never()).getElementById(testId);
+    }
+
     /**
      * Tests that the element correctly becomes deselected when CTRL-clicked.
      * @param robot TestFX robot, injected automatically


### PR DESCRIPTION
Resolves #89.
Affected drag operations are:
- Moving an element
- Resizing an element
- Moving a point of a connector

Expected behavior:
Any of the above operations can only be initiated by left-click dragging. If the user presses right-click while still holding down left-click to drag, the operation will be instantly cancelled. No commands should be run if this happens.

Minimally tested locally. Needs UI tests, but if someone could test this more manually that would be appreciated.