### PR TITLE
Diagram elements add to center of user's screen

### DIFF
--- a/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
+++ b/src/main/java/carleton/sysc4907/DiagramEditorLoader.java
@@ -47,6 +47,7 @@ public class DiagramEditorLoader {
     private MessageConstructor constructor;
 
     private SessionModel sessionModel;
+    private EditingAreaCoordinateProvider editingAreaCoordinateProvider;
 
     /**
      * Constructs a new DiagramEditorLoader.
@@ -138,6 +139,7 @@ public class DiagramEditorLoader {
         PathingStrategyFactory pathingStrategyFactory = new PathingStrategyFactory();
         DependencyInjector elementControllerInjector = new DependencyInjector();
         FileSaver fileSaver = new FileSaver(diagramModel, executedCommandList, commandListCompressor);
+        editingAreaCoordinateProvider = new EditingAreaCoordinateProvider(null);
         ElementCreator elementCreator;
         try {
             elementCreator = new ElementCreator(elementControllerInjector, TEMPLATE_FILE_PATH, elementIdManager);
@@ -254,7 +256,7 @@ public class DiagramEditorLoader {
         injector.addInjectionMethod(DiagramEditingAreaController.class,
                 () -> new DiagramEditingAreaController(diagramModel));
         injector.addInjectionMethod(ElementLibraryPanelController.class,
-                () -> new ElementLibraryPanelController(diagramModel, addCommandFactory, elementCreator, elementIdManager));
+                () -> new ElementLibraryPanelController(diagramModel, addCommandFactory, elementCreator, elementIdManager, editingAreaCoordinateProvider));
 
         // Run the previous commands
         executedCommandRunner.runPreviousCommands(commandArgsList);
@@ -298,6 +300,7 @@ public class DiagramEditorLoader {
         stage.setTitle("Diagram Editor");
         stage.getScene().getWindow().addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, windowEvent -> manager.close());
         interpreter.setWindow(stage.getScene().getWindow());
+        editingAreaCoordinateProvider.setScene(scene);
         System.out.println("Window Was Set");
         stage.show();
     }

--- a/src/main/java/carleton/sysc4907/command/AddCommand.java
+++ b/src/main/java/carleton/sysc4907/command/AddCommand.java
@@ -29,6 +29,8 @@ public class AddCommand implements Command<AddCommandArgs> {
         if (element == null) return; // If the type of element to create is not recognized
         editingArea.getChildren().add(element);
         diagramModel.getElements().add(element);
+        element.setLayoutX(args.x());
+        element.setLayoutY(args.y());
     }
 
     @Override

--- a/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
+++ b/src/main/java/carleton/sysc4907/command/args/AddCommandArgs.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
  * Arguments for the add command
  * @param elementType the type of element to create
  */
-public record AddCommandArgs(String elementType, long elementId) implements Serializable, CommandArgs {
+public record AddCommandArgs(String elementType, double x, double y, long elementId) implements Serializable, CommandArgs {
     @Override
     public long[] getElementIds() {
         return new long[] {elementId};

--- a/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
+++ b/src/main/java/carleton/sysc4907/controller/ElementLibraryPanelController.java
@@ -1,8 +1,10 @@
 package carleton.sysc4907.controller;
 
 import carleton.sysc4907.DependencyInjector;
+import carleton.sysc4907.EditingAreaProvider;
 import carleton.sysc4907.command.AddCommandFactory;
 import carleton.sysc4907.command.args.AddCommandArgs;
+import carleton.sysc4907.processing.EditingAreaCoordinateProvider;
 import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
@@ -35,6 +37,8 @@ public class ElementLibraryPanelController {
     private final ElementCreator elementCreator;
     private final ElementIdManager elementIdManager;
 
+    private final EditingAreaCoordinateProvider coordinateProvider;
+
     /**
      * Constructs a new ElementLibraryPanelController.
      * @param diagramModel the DiagramModel for the current diagram
@@ -43,11 +47,13 @@ public class ElementLibraryPanelController {
             DiagramModel diagramModel,
             AddCommandFactory addCommandFactory,
             ElementCreator elementCreator,
-            ElementIdManager elementIdManager) {
+            ElementIdManager elementIdManager,
+            EditingAreaCoordinateProvider coordinateProvider) {
         this.diagramModel = diagramModel;
         this.addCommandFactory = addCommandFactory;
         this.elementCreator = elementCreator;
         this.elementIdManager = elementIdManager;
+        this.coordinateProvider = coordinateProvider;
     }
 
     @FXML
@@ -68,7 +74,11 @@ public class ElementLibraryPanelController {
         Button button = new Button(elementName);
         button.setOnAction(actionEvent -> {
             int subElementCount = elementCreator.countIdSubElements(elementName);
-            AddCommandArgs args = new AddCommandArgs(elementName, elementIdManager.getNewIdRange(subElementCount));
+            AddCommandArgs args = new AddCommandArgs(
+                    elementName,
+                    coordinateProvider.getCenterVisibleX(),
+                    coordinateProvider.getCenterVisibleY(),
+                    elementIdManager.getNewIdRange(subElementCount));
             var command = addCommandFactory.createTracked(args);
             command.execute();
 

--- a/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
+++ b/src/main/java/carleton/sysc4907/controller/element/ConnectorElementController.java
@@ -17,6 +17,7 @@ import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.*;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.ListChangeListener;
+import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.image.ImageView;
@@ -106,6 +107,7 @@ public class ConnectorElementController extends DiagramElementController {
     public void initialize() {
         super.initialize();
         element.removeEventHandler(MouseEvent.ANY, mouseEventHandler);
+        element.setPickOnBounds(false); // make mouse events trigger on geometric shape of element not its rectangular bounds
         pathHitbox.addEventHandler(MouseEvent.ANY, mouseEventHandler);
         ChangeListener<Number> listener = (observableValue, number, t1) -> {
             reposition();
@@ -164,11 +166,13 @@ public class ConnectorElementController extends DiagramElementController {
             handle.setOnDragDetected(this::handleDragDetectedStartMovePoint);
             handle.setOnMouseDragged(event -> handleMouseDraggedMovePreviewPoint(event, true));
             handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, true));
+            handle.setOnMouseClicked(Event::consume);
             handles.add(handle);
             handle = connectorHandleCreator.createMovePointHandle(element, endX, endY);
             handle.setOnDragDetected(this::handleDragDetectedStartMovePoint);
             handle.setOnMouseDragged(event -> handleMouseDraggedMovePreviewPoint(event, false));
             handle.setOnMouseReleased(event -> handleMouseReleasedResize(event, false));
+            handle.setOnMouseClicked(Event::consume);
             handles.add(handle);
         } else {
             for (Node handle : handles) {
@@ -296,6 +300,7 @@ public class ConnectorElementController extends DiagramElementController {
                     previewController.element.getElementId());
             var command = connectorMovePointCommandFactory.create(args);
             command.execute();
+            event.consume();
         }
     }
 

--- a/src/main/java/carleton/sysc4907/processing/EditingAreaCoordinateProvider.java
+++ b/src/main/java/carleton/sysc4907/processing/EditingAreaCoordinateProvider.java
@@ -4,21 +4,41 @@ import carleton.sysc4907.EditingAreaProvider;
 import javafx.scene.Scene;
 import javafx.scene.control.ScrollPane;
 
+/**
+ * Class to handle finding the coordinates of the visible screen, in diagram space.
+ */
 public class EditingAreaCoordinateProvider {
 
     private Scene scene;
 
     private final String SCROLL_PANE_ID = "scrollPane";
 
+    /**
+     * Constructs a new EditingAreaCoordinateProvider with the given Scene.
+     * @param scene the Scene that contains the editing area
+     */
     public EditingAreaCoordinateProvider(Scene scene) {
         this.scene = scene;
     }
 
+    /**
+     * Sets the scene to look for the editing area in.
+     * @param scene the Scene that contains the editing area
+     */
     public void setScene(Scene scene) {
         this.scene = scene;
     }
 
+    /**
+     * Gets the X (horizontal) coordinate of the center of the visible area of the diagram.
+     * The coordinate returned is in the coordinate space of the editing area, so it can be passed to setLayoutX
+     * for diagram elements.
+     * @return the X-coordinate of the center of the visible diagram area
+     */
     public double getCenterVisibleX() {
+        if (scene == null) {
+            throw new IllegalStateException("EditingAreaCoordinateProvider scene must be set!");
+        }
         var editingAreaScrollPane = (ScrollPane) scene.lookup("#" + SCROLL_PANE_ID);
         var viewportCenter = editingAreaScrollPane.getViewportBounds().getWidth() / 2;
         System.out.println(editingAreaScrollPane.getViewportBounds().getWidth());
@@ -30,7 +50,16 @@ public class EditingAreaCoordinateProvider {
         return viewportCenter + viewportOffset;
     }
 
+    /**
+     * Gets the Y (vertical) coordinate of the center of the visible area of the diagram.
+     * The coordinate returned is in the coordinate space of the editing area, so it can be passed to setLayoutY
+     * for diagram elements.
+     * @return the Y-coordinate of the center of the visible diagram area
+     */
     public double getCenterVisibleY() {
+        if (scene == null) {
+            throw new IllegalStateException("EditingAreaCoordinateProvider scene must be set!");
+        }
         var editingAreaScrollPane = (ScrollPane) scene.lookup("#" + SCROLL_PANE_ID);
         var viewportCenter = editingAreaScrollPane.getViewportBounds().getHeight() / 2;
         var maxScrollDistance = EditingAreaProvider.getEditingArea().getBoundsInLocal().getHeight() - editingAreaScrollPane.getViewportBounds().getHeight();

--- a/src/main/java/carleton/sysc4907/processing/EditingAreaCoordinateProvider.java
+++ b/src/main/java/carleton/sysc4907/processing/EditingAreaCoordinateProvider.java
@@ -1,0 +1,41 @@
+package carleton.sysc4907.processing;
+
+import carleton.sysc4907.EditingAreaProvider;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+
+public class EditingAreaCoordinateProvider {
+
+    private Scene scene;
+
+    private final String SCROLL_PANE_ID = "scrollPane";
+
+    public EditingAreaCoordinateProvider(Scene scene) {
+        this.scene = scene;
+    }
+
+    public void setScene(Scene scene) {
+        this.scene = scene;
+    }
+
+    public double getCenterVisibleX() {
+        var editingAreaScrollPane = (ScrollPane) scene.lookup("#" + SCROLL_PANE_ID);
+        var viewportCenter = editingAreaScrollPane.getViewportBounds().getWidth() / 2;
+        System.out.println(editingAreaScrollPane.getViewportBounds().getWidth());
+        System.out.println(editingAreaScrollPane.getHvalue());
+        var maxScrollDistance = EditingAreaProvider.getEditingArea().getBoundsInLocal().getWidth() - editingAreaScrollPane.getViewportBounds().getWidth();
+        var viewportOffset = editingAreaScrollPane.getHvalue() * maxScrollDistance / (editingAreaScrollPane.getHmax() - editingAreaScrollPane.getHmin());
+        System.out.println(viewportOffset);
+
+        return viewportCenter + viewportOffset;
+    }
+
+    public double getCenterVisibleY() {
+        var editingAreaScrollPane = (ScrollPane) scene.lookup("#" + SCROLL_PANE_ID);
+        var viewportCenter = editingAreaScrollPane.getViewportBounds().getHeight() / 2;
+        var maxScrollDistance = EditingAreaProvider.getEditingArea().getBoundsInLocal().getHeight() - editingAreaScrollPane.getViewportBounds().getHeight();
+        var viewportOffset = editingAreaScrollPane.getVvalue() * maxScrollDistance / (editingAreaScrollPane.getVmax() - editingAreaScrollPane.getVmin());
+
+        return viewportCenter + viewportOffset;
+    }
+}

--- a/src/main/java/carleton/sysc4907/processing/EditingAreaCoordinateProvider.java
+++ b/src/main/java/carleton/sysc4907/processing/EditingAreaCoordinateProvider.java
@@ -24,7 +24,7 @@ public class EditingAreaCoordinateProvider {
         System.out.println(editingAreaScrollPane.getViewportBounds().getWidth());
         System.out.println(editingAreaScrollPane.getHvalue());
         var maxScrollDistance = EditingAreaProvider.getEditingArea().getBoundsInLocal().getWidth() - editingAreaScrollPane.getViewportBounds().getWidth();
-        var viewportOffset = editingAreaScrollPane.getHvalue() * maxScrollDistance / (editingAreaScrollPane.getHmax() - editingAreaScrollPane.getHmin());
+        var viewportOffset = editingAreaScrollPane.getHvalue() * maxScrollDistance;
         System.out.println(viewportOffset);
 
         return viewportCenter + viewportOffset;
@@ -34,7 +34,7 @@ public class EditingAreaCoordinateProvider {
         var editingAreaScrollPane = (ScrollPane) scene.lookup("#" + SCROLL_PANE_ID);
         var viewportCenter = editingAreaScrollPane.getViewportBounds().getHeight() / 2;
         var maxScrollDistance = EditingAreaProvider.getEditingArea().getBoundsInLocal().getHeight() - editingAreaScrollPane.getViewportBounds().getHeight();
-        var viewportOffset = editingAreaScrollPane.getVvalue() * maxScrollDistance / (editingAreaScrollPane.getVmax() - editingAreaScrollPane.getVmin());
+        var viewportOffset = editingAreaScrollPane.getVvalue() * maxScrollDistance;
 
         return viewportCenter + viewportOffset;
     }

--- a/src/main/resources/carleton/sysc4907/view/DiagramEditingArea.fxml
+++ b/src/main/resources/carleton/sysc4907/view/DiagramEditingArea.fxml
@@ -11,6 +11,7 @@
             fx:controller="carleton.sysc4907.controller.DiagramEditingAreaController"
             fx:id="scrollPane"
             prefHeight="400.0" prefWidth="600.0"
+            pannable="true"
             stylesheets="/stylesheet/DiagramElementsStyle.css">
 
     <Pane fx:id="editingArea" prefHeight="3000" prefWidth="3000">

--- a/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
+++ b/src/test/java/carleton/sysc4907/command/AddCommandFactoryTest.java
@@ -20,7 +20,7 @@ public class AddCommandFactoryTest {
         DiagramModel diagramModel = new DiagramModel();
         ElementCreator mockElementCreator = Mockito.mock(ElementCreator.class);
         ExecutedCommandList mockExecutedCommandList = Mockito.mock(ExecutedCommandList.class);
-        AddCommandArgs args = new AddCommandArgs(fxmlPath, 0);
+        AddCommandArgs args = new AddCommandArgs(fxmlPath, 0, 0, 0);
         Manager mockManager = Mockito.mock(Manager.class);
         MessageConstructor mockMessageConstructor = Mockito.mock(MessageConstructor.class);
         AddCommandFactory factory = new AddCommandFactory(diagramModel, mockElementCreator, mockManager, mockExecutedCommandList, mockMessageConstructor);

--- a/src/test/java/carleton/sysc4907/command/CommandListCompressorTest.java
+++ b/src/test/java/carleton/sysc4907/command/CommandListCompressorTest.java
@@ -51,8 +51,8 @@ public class CommandListCompressorTest {
         var testId = 12L;
         var testId2 = 13L;
         List<Command<?>> commandList = new LinkedList<>();
-        commandList.add(new AddCommand(new AddCommandArgs("test", testId), diagramModel, elementCreator));
-        var addCmd = new AddCommand(new AddCommandArgs("test", testId), diagramModel, elementCreator);
+        commandList.add(new AddCommand(new AddCommandArgs("test", 0, 0, testId), diagramModel, elementCreator));
+        var addCmd = new AddCommand(new AddCommandArgs("test", 0, 0, testId), diagramModel, elementCreator);
         commandList.add(addCmd);
         commandList.add(new EditTextCommand(new EditTextCommandArgs("new text", testId2), elementIdManager));
         var editCmd = new EditTextCommand(new EditTextCommandArgs("newer text", testId2), elementIdManager);
@@ -91,7 +91,7 @@ public class CommandListCompressorTest {
         var testId = 12L;
         var testId2 = 13L;
         List<Command<?>> commandList = new LinkedList<>();
-        commandList.add(new AddCommand(new AddCommandArgs("test", testId), diagramModel, elementCreator));
+        commandList.add(new AddCommand(new AddCommandArgs("test", 0, 0, testId), diagramModel, elementCreator));
         commandList.add(new EditTextCommand(new EditTextCommandArgs("new text", testId2), elementIdManager));
         commandList.add(new ResizeCommand(new ResizeCommandArgs(
                 false, true,

--- a/src/test/java/carleton/sysc4907/processing/FileSaveLoadTest.java
+++ b/src/test/java/carleton/sysc4907/processing/FileSaveLoadTest.java
@@ -50,7 +50,7 @@ public class FileSaveLoadTest {
         String filePath = temp.getPath();
         // Populate an executed command list
         var addCommand = new AddCommand(
-                new AddCommandArgs("", 120L),
+                new AddCommandArgs("", 0, 0, 120L),
                 diagramModel,
                 mockElementCreator
         );

--- a/src/test/java/carleton/sysc4907/ui/command/AddCommandTest.java
+++ b/src/test/java/carleton/sysc4907/ui/command/AddCommandTest.java
@@ -75,7 +75,7 @@ public class AddCommandTest {
             Mockito.when(mockElementCreator.create(eq("testType"), anyLong(), eq(true)))
                     .thenReturn(mockDiagramElement);
 
-            AddCommandArgs args = new AddCommandArgs("testType", 2L);
+            AddCommandArgs args = new AddCommandArgs("testType", 0, 0, 2L);
             AddCommand command = new AddCommand(args, mockDiagramModel, mockElementCreator);
 
             //execute

--- a/src/test/java/carleton/sysc4907/ui/processing/EditingAreaCoordinateProviderTest.java
+++ b/src/test/java/carleton/sysc4907/ui/processing/EditingAreaCoordinateProviderTest.java
@@ -1,0 +1,78 @@
+package carleton.sysc4907.ui.processing;
+
+import carleton.sysc4907.EditingAreaProvider;
+import carleton.sysc4907.processing.EditingAreaCoordinateProvider;
+import javafx.geometry.Bounds;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.Pane;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(ApplicationExtension.class)
+public class EditingAreaCoordinateProviderTest {
+
+    @Mock
+    private Scene mockScene;
+
+    private ScrollPane mockScrollPane;
+
+    @Mock
+    private Bounds mockViewportBounds;
+
+    @Mock
+    private Pane mockEditingArea;
+
+    @Mock
+    private Bounds mockEditingAreaBounds;
+
+    private EditingAreaCoordinateProvider coordinateProvider;
+
+    @BeforeEach
+    void setup() {
+        mockScrollPane = Mockito.mock(ScrollPane.class);
+        coordinateProvider = new EditingAreaCoordinateProvider(mockScene);
+    }
+
+    @Test
+    void testGetCenterVisibleX() {
+        when(mockScene.lookup("#scrollPane")).thenReturn(mockScrollPane);
+        when(mockScrollPane.getViewportBounds()).thenReturn(mockViewportBounds);
+        when(mockEditingArea.getBoundsInLocal()).thenReturn(mockEditingAreaBounds);
+        when(mockViewportBounds.getWidth()).thenReturn(1000.0);
+        when(mockEditingAreaBounds.getWidth()).thenReturn(5000.0);
+        when(mockScrollPane.getHvalue()).thenReturn(0.1);
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+
+            var result = coordinateProvider.getCenterVisibleX();
+            assertEquals(900.0, result);
+        }
+    }
+
+    @Test
+    void testGetCenterVisibleY() {
+        when(mockScene.lookup("#scrollPane")).thenReturn(mockScrollPane);
+        when(mockScrollPane.getViewportBounds()).thenReturn(mockViewportBounds);
+        when(mockEditingArea.getBoundsInLocal()).thenReturn(mockEditingAreaBounds);
+        when(mockViewportBounds.getHeight()).thenReturn(300.0);
+        when(mockEditingAreaBounds.getHeight()).thenReturn(600.0);
+        when(mockScrollPane.getVvalue()).thenReturn(0.5);
+        try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
+            utilities.when(EditingAreaProvider::getEditingArea).thenReturn(mockEditingArea);
+
+            var result = coordinateProvider.getCenterVisibleY();
+            assertEquals(300.0, result);
+        }
+    }
+}

--- a/src/test/java/carleton/sysc4907/ui/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ElementLibraryPanelTest.java
@@ -8,6 +8,7 @@ import carleton.sysc4907.communications.MessageConstructor;
 import carleton.sysc4907.controller.ElementLibraryPanelController;
 import carleton.sysc4907.model.DiagramModel;
 import carleton.sysc4907.model.ExecutedCommandList;
+import carleton.sysc4907.processing.EditingAreaCoordinateProvider;
 import carleton.sysc4907.processing.ElementCreator;
 import carleton.sysc4907.processing.ElementIdManager;
 import carleton.sysc4907.view.DiagramElement;
@@ -66,6 +67,9 @@ public class ElementLibraryPanelTest {
     @Mock
     private MessageConstructor mockMessageConstructor;
 
+    @Mock
+    private EditingAreaCoordinateProvider coordinateProvider;
+
     @Start
     private void start(Stage stage) throws IOException {
         try (MockedStatic<EditingAreaProvider> utilities = Mockito.mockStatic(EditingAreaProvider.class)) {
@@ -86,7 +90,8 @@ public class ElementLibraryPanelTest {
                                 mockDiagramModel,
                                 addCommandFactory,
                                 mockElementCreator,
-                                mockElementIdManager);
+                                mockElementIdManager,
+                                coordinateProvider);
                         return controller;
                     });
             Scene scene = new Scene(injector.load("view/ElementLibraryPanel.fxml"));
@@ -109,6 +114,8 @@ public class ElementLibraryPanelTest {
                 .thenReturn(mockDiagramElement);
         Mockito.when(mockExecutedCommandList.getCommandList()).thenReturn(new LinkedList<>());
         Mockito.when(mockElementIdManager.getNewIdRange(anyInt())).thenReturn(testId);
+        Mockito.when(coordinateProvider.getCenterVisibleX()).thenReturn(0.0);
+        Mockito.when(coordinateProvider.getCenterVisibleY()).thenReturn(0.0);
 
         robot.clickOn("#elementsPane .button");
 

--- a/src/test/java/carleton/sysc4907/ui/view/ElementLibraryPanelTest.java
+++ b/src/test/java/carleton/sysc4907/ui/view/ElementLibraryPanelTest.java
@@ -114,13 +114,15 @@ public class ElementLibraryPanelTest {
                 .thenReturn(mockDiagramElement);
         Mockito.when(mockExecutedCommandList.getCommandList()).thenReturn(new LinkedList<>());
         Mockito.when(mockElementIdManager.getNewIdRange(anyInt())).thenReturn(testId);
-        Mockito.when(coordinateProvider.getCenterVisibleX()).thenReturn(0.0);
-        Mockito.when(coordinateProvider.getCenterVisibleY()).thenReturn(0.0);
+        Mockito.when(coordinateProvider.getCenterVisibleX()).thenReturn(100.0);
+        Mockito.when(coordinateProvider.getCenterVisibleY()).thenReturn(400.0);
 
         robot.clickOn("#elementsPane .button");
 
         Mockito.verify(mockElementsList).add(any(DiagramElement.class));
         Mockito.verify(mockNodesList).add(any(Node.class));
+        Mockito.verify(mockDiagramElement).setLayoutX(100.0);
+        Mockito.verify(mockDiagramElement).setLayoutY(400.0);
         EditingAreaProvider.init(null);
     }
 }


### PR DESCRIPTION
New elements added will be added to the diagram so their top-left corner is on the center of the diagram parts that the user can see. This element should be added to the same position on clients' ends, regardless of where they are looking.
This should work regardless of the user's screen size and scroll position.